### PR TITLE
Improve load performance from Firebase

### DIFF
--- a/lib/data/model/crop_entity.dart
+++ b/lib/data/model/crop_entity.dart
@@ -12,7 +12,7 @@ class CropEntity {
   List<String> cropsInRotation;
   CropType cropType;
   String imagePathReference;
-  String imageUrl;
+  Future<String> imageUrl;
   String name;
   List<String> nonCompanionPlants;
   LoHi profitability;
@@ -52,7 +52,7 @@ class CropEntity {
         cropsInRotation: extractListOfString(cropDocument, CROP_ROTATION),
         cropType: cropTypeValues.map[cropDocument.data[CROP_TYPE]],
         imagePathReference: cropDocument.data[IMAGE].first.path,
-        imageUrl: "",
+        imageUrl: Future.value(null),
         name: cropDocument.data[NAME],
         nonCompanionPlants:
             extractListOfString(cropDocument, NONCOMPANION_PLANTS),
@@ -69,7 +69,7 @@ class CropEntity {
   /*
    ## Image url is referenced from Firebase Storage, thus, needs to be deducted from firestore's Document, asynchronously and then saved.
    */
-  void setImageUrl(String imageUrl) {
+  void setImageUrl(Future<String> imageUrl) {
     this.imageUrl = imageUrl;
   }
 

--- a/lib/data/repositories/plot_repository.dart
+++ b/lib/data/repositories/plot_repository.dart
@@ -20,11 +20,13 @@ class PlotRepository{
     return _firestoreManager.getCrops();
   }
 
-  Future<List<CropEntity>> getListOfCropStages(List<CropEntity> cropsWithoutStages) {
+  /// Adds stages to the supplied crop entities
+  Future<dynamic> getListOfCropStages(List<CropEntity> cropsWithoutStages) {
     return _firestoreManager.getStages(cropsWithoutStages);
   }
 
-  Future<List<CropEntity>> getListOfCropsWithImages(List<CropEntity> cropsWithoutImages) {
+  /// Adds images to the supplied crop entities
+  Future<dynamic> getListOfCropsWithImages(List<CropEntity> cropsWithoutImages) {
     return _firestoreManager.getCropsImagePath(cropsWithoutImages);
   }
 

--- a/lib/redux/middleware/plot_middleware.dart
+++ b/lib/redux/middleware/plot_middleware.dart
@@ -3,15 +3,24 @@
 import 'package:farmsmart_flutter/data/repositories/plot_repository.dart';
 import 'package:farmsmart_flutter/redux/app/app_state.dart';
 import 'package:farmsmart_flutter/redux/home/myPlot/my_plot_actions.dart';
+import 'package:flutter/foundation.dart';
 import 'package:redux/redux.dart';
 
 class MyPlotMiddleWare extends MiddlewareClass<AppState>{
   @override
   Future call(Store<AppState> store, dynamic action, NextDispatcher next) async {
     if(action is FetchCropListAction) {
+      Stopwatch sw = new Stopwatch();
+      sw.start();
       var listOfCrops = await PlotRepository.get().getListOfCrops();
-      listOfCrops = await PlotRepository.get().getListOfCropStages(listOfCrops);
-      listOfCrops = await PlotRepository.get().getListOfCropsWithImages(listOfCrops);
+      debugPrint('getListOfCrops() ${sw.elapsed.inMilliseconds} ms ');
+      sw.reset();
+      Future fetchStageFuture = PlotRepository.get().getListOfCropStages(listOfCrops);
+      Future fetchImageFuture = PlotRepository.get().getListOfCropsWithImages(listOfCrops);
+      await Future.wait([fetchStageFuture, fetchImageFuture]);
+      debugPrint('getStagesAndImages() ${sw.elapsed.inMilliseconds} ms ');
+      sw.stop();
+      debugPrint('Fetch crop complete.');
       store.dispatch(UpdateCropListAction(listOfCrops));
     }
 

--- a/lib/ui/common/network_image_from_future.dart
+++ b/lib/ui/common/network_image_from_future.dart
@@ -1,0 +1,29 @@
+import 'package:farmsmart_flutter/utils/assets.dart';
+import 'package:flutter/widgets.dart';
+
+class NetworkImageFromFuture extends StatelessWidget {
+  final Future<String> futureUrl;
+  final double height;
+  final double width;
+
+  NetworkImageFromFuture(this.futureUrl, {@required this.height, @required this.width});
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder(
+        future: futureUrl,
+        builder: (BuildContext context, AsyncSnapshot snapshot) {
+          if (snapshot.hasData) {
+            return FadeInImage.assetNetwork(
+                image: snapshot.data.toString(),
+                height: height,
+                width: width,
+                placeholder: Assets.IMAGE_PLACE_HOLDER,
+                fit: BoxFit.fitWidth);
+          } else {
+            return Container(width: width, height: height,); // placeholder
+          }
+        }
+    );
+  }
+}

--- a/lib/ui/myplot/my_plot_child_item.dart
+++ b/lib/ui/myplot/my_plot_child_item.dart
@@ -1,4 +1,5 @@
 import 'package:farmsmart_flutter/data/model/crop_entity.dart';
+import 'package:farmsmart_flutter/ui/common/network_image_from_future.dart';
 import 'package:farmsmart_flutter/ui/myplot/my_plot_item_footer.dart';
 import 'package:farmsmart_flutter/utils/assets.dart';
 import 'package:farmsmart_flutter/utils/box_shadows.dart';
@@ -24,12 +25,11 @@ class MyPlotListItem {
                   topLeft: Radius.circular(8.0),
                   topRight: Radius.circular(8.0),
                 ),
-                child: FadeInImage.assetNetwork(
-                    image: cropsData.imageUrl,
-                    height: listImageHeight,
-                    width: listImageWidth,
-                    placeholder: Assets.IMAGE_PLACE_HOLDER,
-                    fit: BoxFit.fitWidth),
+                child: NetworkImageFromFuture(
+                  cropsData.imageUrl,
+                  height: listImageHeight,
+                  width: listImageWidth
+                ),
               ),
               Padding(
                   padding: Paddings.boxBigPadding(),

--- a/lib/ui/myplot/my_plot_detail_screen.dart
+++ b/lib/ui/myplot/my_plot_detail_screen.dart
@@ -1,5 +1,6 @@
 import 'package:farmsmart_flutter/data/model/crop_entity.dart';
 import 'package:farmsmart_flutter/model/crop_detail_property.dart';
+import 'package:farmsmart_flutter/ui/common/network_image_from_future.dart';
 import 'package:farmsmart_flutter/utils/assets.dart';
 import 'package:farmsmart_flutter/utils/colors.dart';
 import 'package:farmsmart_flutter/utils/dimens.dart';
@@ -43,12 +44,11 @@ class _CropDetailState extends State<CropDetailScreen> {
               borderRadius: BorderRadius.circular(8.0),
             ),
             child: ListView(children: <Widget>[
-              FadeInImage.assetNetwork(
-                  image: selectedCropData.imageUrl,
+              NetworkImageFromFuture(
+                  selectedCropData.imageUrl,
                   height: listImageHeight,
-                  width: listImageWidth,
-                  placeholder: Assets.IMAGE_PLACE_HOLDER,
-                  fit: BoxFit.fitWidth),
+                  width: listImageWidth
+              ),
               Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[


### PR DESCRIPTION
[[FARM-323- Please use Spring JIRA ticket and not subtasks](https://amidodevelopment.atlassian.net/browse/FARM-323)]

#### 📲 What

Vastly improve the load performance of My Plot screen to demonstrate a better way of using awaits and futures.
Introduce a FutureBuilder for loading image assets.

#### 🤔 Why
		
The app load takes a very long time for more than 3 crops. 6 crops took 10s.
With the changes, initial load takes under 1s.
		
#### 🛠 How
		
Reduced the synchronous 'await' calls to firebase api calls and returned futures instead. The main await call is invoked from the middleware.

Additionally, the fetching and displaying of the image download url from firebase cloud store (bucket) is now done asynchronously via FutureBuilder

#### 👀 See
		
See the latest build channel for the latest link to a working APK
		 
#### ✅ Acceptance criteria

- [x] Snappy Load

#### Coding Standards Checklist
- [x] Reduce synchronous await calls and use Futures more.

Recommended Style Guide: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo

#### 🕵️‍♂️ How to test

Notes for QA
See the latest build channel for the latest link to a working APK

#### Reviewers

@farmsmart/amido @farmsmart/wamf
