### PR TITLE
Feature/farm 278 ui update crop details

### DIFF
--- a/lib/ui/common/carousel_view.dart
+++ b/lib/ui/common/carousel_view.dart
@@ -2,7 +2,7 @@ import 'package:flutter/widgets.dart';
 
 class _DefaultConstants {
   static const int _initialPage = 0;
-  static const double _viewPortFraction = 0.8;
+  static const double _viewPortFraction = 0.85;
 }
 
 class CarouselView extends StatelessWidget {

--- a/lib/ui/common/carousel_view.dart
+++ b/lib/ui/common/carousel_view.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+import 'stage_card.dart';
+
+class CarouselView extends StatefulWidget {
+  @override
+  _CarouselViewState createState() => _CarouselViewState();
+}
+
+class _CarouselViewState extends State<CarouselView> {
+  @override
+  Widget build(BuildContext context) {
+    return PageView(
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: StageCard(),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: StageCard(),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: StageCard(),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: StageCard(),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: StageCard(),
+        ),
+      ],
+      controller: PageController(viewportFraction: 0.8, initialPage: 0),
+    );
+    //onPagechanged
+  }
+}

--- a/lib/ui/common/carousel_view.dart
+++ b/lib/ui/common/carousel_view.dart
@@ -1,41 +1,26 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
-import 'stage_card.dart';
-
-class CarouselView extends StatefulWidget {
-  @override
-  _CarouselViewState createState() => _CarouselViewState();
+class _DefaultConstants {
+  static const int _initialPage = 0;
+  static const double _viewPortFraction = 0.8;
 }
 
-class _CarouselViewState extends State<CarouselView> {
+class CarouselView extends StatelessWidget {
+  final List<Widget> children;
+  final double viewPortFraction;
+  final int initialPage;
+
+  const CarouselView({
+    @required this.children,
+    this.viewPortFraction = _DefaultConstants._viewPortFraction,
+    this.initialPage = _DefaultConstants._initialPage,
+  });
+
   @override
   Widget build(BuildContext context) {
     return PageView(
-      children: <Widget>[
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: StageCard(),
-        ),
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: StageCard(),
-        ),
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: StageCard(),
-        ),
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: StageCard(),
-        ),
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: StageCard(),
-        ),
-      ],
-      controller: PageController(viewportFraction: 0.8, initialPage: 0),
+      children: children,
+      controller: PageController(viewportFraction: viewPortFraction, initialPage: initialPage),
     );
-    //onPagechanged
   }
 }

--- a/lib/ui/common/stage_card.dart
+++ b/lib/ui/common/stage_card.dart
@@ -1,3 +1,4 @@
+import 'package:farmsmart_flutter/ui/common/Dogtag.dart';
 import 'package:farmsmart_flutter/ui/common/roundedButton.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
@@ -11,8 +12,7 @@ class StateCardViewModel {
   String inactiveButtonText;
   Function actionButton;
 
-  StateCardViewModel(
-      this.stageNumber,
+  StateCardViewModel(this.stageNumber,
       this.stageTitle,
       this.stateStatusText,
       this.completeText,
@@ -28,23 +28,21 @@ abstract class StageCardStyle {
   final TextStyle stageNumberTextStyle;
   final TextStyle stageTitleTextStyle;
 
-  StageCardStyle(
-      this.cardCornerRadius,
+  StageCardStyle(this.cardCornerRadius,
       this.cardBackgroundColor,
       this.cardContentPadding,
       this.stageNumberTextStyle,
       this.stageTitleTextStyle);
 
-  StageCardStyle copyWith(
-      {double cardCornerRadius,
-      Color cardBackgroundColor,
-      EdgeInsets cardContentPadding});
+  StageCardStyle copyWith({double cardCornerRadius,
+    Color cardBackgroundColor,
+    EdgeInsets cardContentPadding});
 }
 
 class _DefaultStyle implements StageCardStyle {
   final double cardCornerRadius = 20.0;
   final Color cardBackgroundColor = const Color(0xFFf5f8fa);
-  final EdgeInsets cardContentPadding = const EdgeInsets.all(16);
+  final EdgeInsets cardContentPadding = const EdgeInsets.symmetric(horizontal: 24, vertical: 20);
   final TextStyle stageNumberTextStyle = const TextStyle(
     color: Color(0xFF767690),
     fontSize: 15,
@@ -86,10 +84,9 @@ class StageCard extends StatefulWidget {
   final StateCardViewModel _viewModel;
   final StageCardStyle _style;
 
-  StageCard(
-      {Key key,
-      StateCardViewModel viewModel,
-      StageCardStyle style = _defaultStyle})
+  StageCard({Key key,
+    StateCardViewModel viewModel,
+    StageCardStyle style = _defaultStyle})
       : this._viewModel = viewModel,
         this._style = style,
         super(key: key);
@@ -114,7 +111,7 @@ class _StageCardState extends State<StageCard> {
       child: Padding(
         padding: widget._style.cardContentPadding,
         child: Column(
-          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: <Widget>[
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -127,6 +124,8 @@ class _StageCardState extends State<StageCard> {
                       'Stage 2',
                       style: widget._style.stageNumberTextStyle,
                     ),
+                    SizedBox(height: 8,)
+                    ,
                     Text(
                       //TODO replace string by viewModel
                       'Planting',
@@ -134,30 +133,32 @@ class _StageCardState extends State<StageCard> {
                     ),
                   ],
                 ),
-
-                //TODO: replace by Dogtag
-                Container(
-                  child: Padding(
-                    padding: const EdgeInsets.all(6.0),
-                    child: Text(
-                      //TODO replace string by viewModel
-                      'Completed',
-                      textAlign: TextAlign.center,
-                    ),
+                DogTag(
+                  viewModel: DogTagViewModel(
+                    title: 'Completed',
                   ),
-                  decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(20.0),
-                      color: Colors.green),
+                  style: DogTagStyle.defaultStyle().copyWith(
+                    backgroundColor: Color(0xff24d900),
+                    titleTextStyle: TextStyle(color: Color(0xffffffff),fontSize: 11, fontWeight: FontWeight.bold),
+
+
+                  ),
                 ),
               ],
             ),
-            //Replace by rounded button well done
-            RoundedButton.build(
-              context: context,
-              //TODO replace string by viewModel
-              title: 'Mark as Complete',
-              //TODO replace function by viewModel
-              onTap: () {},
+            RoundedButton(
+              viewModel: RoundedButtonViewModel(
+                  title: 'Revert to In Progress', onTap: () {}),
+              style: RoundedButtonStyle.defaultStyle().copyWith(
+                backgroundColor: Color(0xffe9eaf2),
+                borderRadius: BorderRadius.all(Radius.circular(16)),
+                edgePadding: EdgeInsets.only(left: 0, top: 10, right: 0, bottom: 0),
+                buttonTextStyle: TextStyle(
+                    fontSize: 13, fontWeight: FontWeight.bold, color: Color(0xff4c4e6e)),
+                iconEdgePadding: 5,
+                height: 45,
+                width: double.infinity,
+                buttonIconSize: null,),
             )
           ],
         ),

--- a/lib/ui/common/stage_card.dart
+++ b/lib/ui/common/stage_card.dart
@@ -3,22 +3,32 @@ import 'package:farmsmart_flutter/ui/common/roundedButton.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
-class StateCardViewModel {
-  String stageNumber;
-  String stageTitle;
-  String stateStatusText;
-  String completeText;
-  String activeButtonText;
-  String inactiveButtonText;
+enum Stage { upcoming, inProgress, complete }
+
+class StageStatus {
+  Stage stage;
+  String stageStatusText;
+  String actionText;
   Function actionButton;
 
-  StateCardViewModel(this.stageNumber,
-      this.stageTitle,
-      this.stateStatusText,
-      this.completeText,
-      this.activeButtonText,
-      this.inactiveButtonText,
-      this.actionButton);
+  StageStatus({
+    this.stage,
+    this.stageStatusText,
+    this.actionText,
+    this.actionButton,
+  });
+}
+
+class StageCardViewModel {
+  String stageNumber;
+  String stageTitle;
+  StageStatus stageStatus;
+
+  StageCardViewModel({
+    this.stageNumber,
+    this.stageTitle,
+    this.stageStatus
+  });
 }
 
 abstract class StageCardStyle {
@@ -28,21 +38,26 @@ abstract class StageCardStyle {
   final TextStyle stageNumberTextStyle;
   final TextStyle stageTitleTextStyle;
 
-  StageCardStyle(this.cardCornerRadius,
-      this.cardBackgroundColor,
-      this.cardContentPadding,
-      this.stageNumberTextStyle,
-      this.stageTitleTextStyle);
+  StageCardStyle(
+    this.cardCornerRadius,
+    this.cardBackgroundColor,
+    this.cardContentPadding,
+    this.stageNumberTextStyle,
+    this.stageTitleTextStyle,
+  );
 
-  StageCardStyle copyWith({double cardCornerRadius,
+  StageCardStyle copyWith({
+    double cardCornerRadius,
     Color cardBackgroundColor,
-    EdgeInsets cardContentPadding});
+    EdgeInsets cardContentPadding,
+  });
 }
 
 class _DefaultStyle implements StageCardStyle {
   final double cardCornerRadius = 20.0;
   final Color cardBackgroundColor = const Color(0xFFf5f8fa);
-  final EdgeInsets cardContentPadding = const EdgeInsets.symmetric(horizontal: 24, vertical: 20);
+  final EdgeInsets cardContentPadding =
+      const EdgeInsets.symmetric(horizontal: 24, vertical: 20);
   final TextStyle stageNumberTextStyle = const TextStyle(
     color: Color(0xFF767690),
     fontSize: 15,
@@ -53,13 +68,12 @@ class _DefaultStyle implements StageCardStyle {
     fontWeight: FontWeight.bold,
   );
 
-  const _DefaultStyle({
-    double cardCornerRadius,
-    Color cardBackgroundColor,
-    EdgeInsets cardContentPadding,
-    TextStyle stageNumberTextStyle,
-    TextStyle stageTitleTextStyle,
-  });
+  const _DefaultStyle(
+      {double cardCornerRadius,
+      Color cardBackgroundColor,
+      EdgeInsets cardContentPadding,
+      TextStyle stageNumberTextStyle,
+      TextStyle stageTitleTextStyle,});
 
   @override
   StageCardStyle copyWith({
@@ -81,12 +95,13 @@ class _DefaultStyle implements StageCardStyle {
 const StageCardStyle _defaultStyle = const _DefaultStyle();
 
 class StageCard extends StatefulWidget {
-  final StateCardViewModel _viewModel;
+  final StageCardViewModel _viewModel;
   final StageCardStyle _style;
 
-  StageCard({Key key,
-    StateCardViewModel viewModel,
-    StageCardStyle style = _defaultStyle})
+  StageCard(
+      {Key key,
+      @required StageCardViewModel viewModel,
+      StageCardStyle style = _defaultStyle})
       : this._viewModel = viewModel,
         this._style = style,
         super(key: key);
@@ -96,6 +111,25 @@ class StageCard extends StatefulWidget {
 }
 
 class _StageCardState extends State<StageCard> {
+  static RoundedButtonStyle _actionButtonStyle =
+      RoundedButtonStyle.defaultStyle().copyWith(
+    backgroundColor: Color(0xff24d900),
+    borderRadius: BorderRadius.all(Radius.circular(16)),
+    edgePadding: EdgeInsets.only(left: 0, top: 10, right: 0, bottom: 0),
+    buttonTextStyle: TextStyle(
+        fontSize: 13, fontWeight: FontWeight.bold, color: Color(0xffffffff)),
+    iconEdgePadding: 5,
+    height: 45,
+    width: double.infinity,
+    buttonIconSize: null,
+  );
+
+  RoundedButtonStyle _revertActionButtonStyle = _actionButtonStyle.copyWith(
+    backgroundColor: Color(0xffe9eaf2),
+    buttonTextStyle: TextStyle(
+        fontSize: 13, fontWeight: FontWeight.bold, color: Color(0xff4c4e6e)),
+  );
+
   @override
   void initState() {
     // TODO: implement initState
@@ -124,8 +158,9 @@ class _StageCardState extends State<StageCard> {
                       'Stage 2',
                       style: widget._style.stageNumberTextStyle,
                     ),
-                    SizedBox(height: 8,)
-                    ,
+                    SizedBox(
+                      height: 2,
+                    ),
                     Text(
                       //TODO replace string by viewModel
                       'Planting',
@@ -135,13 +170,14 @@ class _StageCardState extends State<StageCard> {
                 ),
                 DogTag(
                   viewModel: DogTagViewModel(
-                    title: 'Completed',
+                    title: 'Complete',
                   ),
                   style: DogTagStyle.defaultStyle().copyWith(
                     backgroundColor: Color(0xff24d900),
-                    titleTextStyle: TextStyle(color: Color(0xffffffff),fontSize: 11, fontWeight: FontWeight.bold),
-
-
+                    titleTextStyle: TextStyle(
+                        color: Color(0xffffffff),
+                        fontSize: 11,
+                        fontWeight: FontWeight.bold),
                   ),
                 ),
               ],
@@ -149,16 +185,7 @@ class _StageCardState extends State<StageCard> {
             RoundedButton(
               viewModel: RoundedButtonViewModel(
                   title: 'Revert to In Progress', onTap: () {}),
-              style: RoundedButtonStyle.defaultStyle().copyWith(
-                backgroundColor: Color(0xffe9eaf2),
-                borderRadius: BorderRadius.all(Radius.circular(16)),
-                edgePadding: EdgeInsets.only(left: 0, top: 10, right: 0, bottom: 0),
-                buttonTextStyle: TextStyle(
-                    fontSize: 13, fontWeight: FontWeight.bold, color: Color(0xff4c4e6e)),
-                iconEdgePadding: 5,
-                height: 45,
-                width: double.infinity,
-                buttonIconSize: null,),
+              style: _actionButtonStyle,
             )
           ],
         ),

--- a/lib/ui/common/stage_card.dart
+++ b/lib/ui/common/stage_card.dart
@@ -1,0 +1,167 @@
+import 'package:farmsmart_flutter/ui/common/roundedButton.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+class StateCardViewModel {
+  String stageNumber;
+  String stageTitle;
+  String stateStatusText;
+  String completeText;
+  String activeButtonText;
+  String inactiveButtonText;
+  Function actionButton;
+
+  StateCardViewModel(
+      this.stageNumber,
+      this.stageTitle,
+      this.stateStatusText,
+      this.completeText,
+      this.activeButtonText,
+      this.inactiveButtonText,
+      this.actionButton);
+}
+
+abstract class StageCardStyle {
+  final double cardCornerRadius;
+  final Color cardBackgroundColor;
+  final EdgeInsets cardContentPadding;
+  final TextStyle stageNumberTextStyle;
+  final TextStyle stageTitleTextStyle;
+
+  StageCardStyle(
+      this.cardCornerRadius,
+      this.cardBackgroundColor,
+      this.cardContentPadding,
+      this.stageNumberTextStyle,
+      this.stageTitleTextStyle);
+
+  StageCardStyle copyWith(
+      {double cardCornerRadius,
+      Color cardBackgroundColor,
+      EdgeInsets cardContentPadding});
+}
+
+class _DefaultStyle implements StageCardStyle {
+  final double cardCornerRadius = 20.0;
+  final Color cardBackgroundColor = const Color(0xFFf5f8fa);
+  final EdgeInsets cardContentPadding = const EdgeInsets.all(16);
+  final TextStyle stageNumberTextStyle = const TextStyle(
+    color: Color(0xFF767690),
+    fontSize: 15,
+  );
+  final TextStyle stageTitleTextStyle = const TextStyle(
+    color: Color(0xFF1A1B46),
+    fontSize: 20,
+    fontWeight: FontWeight.bold,
+  );
+
+  const _DefaultStyle({
+    double cardCornerRadius,
+    Color cardBackgroundColor,
+    EdgeInsets cardContentPadding,
+    TextStyle stageNumberTextStyle,
+    TextStyle stageTitleTextStyle,
+  });
+
+  @override
+  StageCardStyle copyWith({
+    double cardCornerRadius,
+    Color cardBackgroundColor,
+    EdgeInsets cardContentPadding,
+    TextStyle stageNumberTextStyle,
+    TextStyle stageTitleTextStyle,
+  }) {
+    return _DefaultStyle(
+        cardCornerRadius: cardCornerRadius ?? this.cardCornerRadius,
+        cardBackgroundColor: cardBackgroundColor ?? this.cardBackgroundColor,
+        cardContentPadding: cardContentPadding ?? this.cardContentPadding,
+        stageNumberTextStyle: stageNumberTextStyle ?? this.stageNumberTextStyle,
+        stageTitleTextStyle: stageTitleTextStyle ?? this.stageTitleTextStyle);
+  }
+}
+
+const StageCardStyle _defaultStyle = const _DefaultStyle();
+
+class StageCard extends StatefulWidget {
+  final StateCardViewModel _viewModel;
+  final StageCardStyle _style;
+
+  StageCard(
+      {Key key,
+      StateCardViewModel viewModel,
+      StageCardStyle style = _defaultStyle})
+      : this._viewModel = viewModel,
+        this._style = style,
+        super(key: key);
+
+  @override
+  _StageCardState createState() => _StageCardState();
+}
+
+class _StageCardState extends State<StageCard> {
+  @override
+  void initState() {
+    // TODO: implement initState
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(widget._style.cardCornerRadius),
+          color: widget._style.cardBackgroundColor),
+      child: Padding(
+        padding: widget._style.cardContentPadding,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      //TODO replace string by viewModel
+                      'Stage 2',
+                      style: widget._style.stageNumberTextStyle,
+                    ),
+                    Text(
+                      //TODO replace string by viewModel
+                      'Planting',
+                      style: widget._style.stageTitleTextStyle,
+                    ),
+                  ],
+                ),
+
+                //TODO: replace by Dogtag
+                Container(
+                  child: Padding(
+                    padding: const EdgeInsets.all(6.0),
+                    child: Text(
+                      //TODO replace string by viewModel
+                      'Completed',
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                  decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(20.0),
+                      color: Colors.green),
+                ),
+              ],
+            ),
+            //Replace by rounded button well done
+            RoundedButton.build(
+              context: context,
+              //TODO replace string by viewModel
+              title: 'Mark as Complete',
+              //TODO replace function by viewModel
+              onTap: () {},
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/common/stage_card.dart
+++ b/lib/ui/common/stage_card.dart
@@ -3,57 +3,65 @@ import 'package:farmsmart_flutter/ui/common/roundedButton.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
-enum Stage { upcoming, inProgress, complete }
-
-class StageStatus {
-  Stage stage;
-  String stageStatusText;
-  String actionText;
-  Function actionButton;
-
-  StageStatus({
-    this.stage,
-    this.stageStatusText,
-    this.actionText,
-    this.actionButton,
-  });
-}
+export 'package:farmsmart_flutter/ui/common/Dogtag.dart';
+export 'package:farmsmart_flutter/ui/common/roundedButton.dart';
 
 class StageCardViewModel {
   String stageNumber;
   String stageTitle;
-  StageStatus stageStatus;
+  String actionButtonText;
+  String stageStatusTitle;
+  Function actionButton;
+  IconData dogTagIcon;
 
-  StageCardViewModel({
-    this.stageNumber,
-    this.stageTitle,
-    this.stageStatus
-  });
+  StageCardViewModel(
+      {this.stageNumber,
+      this.stageTitle,
+      this.actionButtonText,
+      this.stageStatusTitle,
+      this.actionButton,
+      this.dogTagIcon});
 }
 
-abstract class StageCardStyle {
+class StageCardStyle {
   final double cardCornerRadius;
   final Color cardBackgroundColor;
   final EdgeInsets cardContentPadding;
   final TextStyle stageNumberTextStyle;
   final TextStyle stageTitleTextStyle;
+  final RoundedButtonStyle actionButtonStyle;
+  final DogTagStyle stageTagStyle;
 
-  StageCardStyle(
+  const StageCardStyle({
     this.cardCornerRadius,
     this.cardBackgroundColor,
     this.cardContentPadding,
     this.stageNumberTextStyle,
     this.stageTitleTextStyle,
-  );
-
-  StageCardStyle copyWith({
-    double cardCornerRadius,
-    Color cardBackgroundColor,
-    EdgeInsets cardContentPadding,
+    this.actionButtonStyle,
+    this.stageTagStyle,
   });
+
+  StageCardStyle copyWith(
+      {double cardCornerRadius,
+      Color cardBackgroundColor,
+      EdgeInsets cardContentPadding,
+      TextStyle stageNumberTextStyle,
+      TextStyle stageTitleTextStyle,
+      RoundedButtonStyle actionButtonStyle,
+      DogTagStyle stageTagStyle}) {
+    return StageCardStyle(
+        cardCornerRadius: cardCornerRadius ?? this.cardCornerRadius,
+        cardBackgroundColor: cardBackgroundColor ?? this.cardBackgroundColor,
+        cardContentPadding: cardContentPadding ?? this.cardContentPadding,
+        stageNumberTextStyle: stageNumberTextStyle ?? this.stageNumberTextStyle,
+        stageTitleTextStyle: stageTitleTextStyle ?? this.stageTitleTextStyle,
+        actionButtonStyle: actionButtonStyle ?? this.actionButtonStyle,
+        stageTagStyle: stageTagStyle ?? this.stageTagStyle);
+  }
 }
 
-class _DefaultStyle implements StageCardStyle {
+class _DefaultStyle extends StageCardStyle {
   final double cardCornerRadius = 20.0;
   final Color cardBackgroundColor = const Color(0xFFf5f8fa);
   final EdgeInsets cardContentPadding =
@@ -67,125 +75,106 @@ class _DefaultStyle implements StageCardStyle {
     fontSize: 20,
     fontWeight: FontWeight.bold,
   );
-
-  const _DefaultStyle(
-      {double cardCornerRadius,
-      Color cardBackgroundColor,
-      EdgeInsets cardContentPadding,
-      TextStyle stageNumberTextStyle,
-      TextStyle stageTitleTextStyle,});
-
-  @override
-  StageCardStyle copyWith({
-    double cardCornerRadius,
-    Color cardBackgroundColor,
-    EdgeInsets cardContentPadding,
-    TextStyle stageNumberTextStyle,
-    TextStyle stageTitleTextStyle,
-  }) {
-    return _DefaultStyle(
-        cardCornerRadius: cardCornerRadius ?? this.cardCornerRadius,
-        cardBackgroundColor: cardBackgroundColor ?? this.cardBackgroundColor,
-        cardContentPadding: cardContentPadding ?? this.cardContentPadding,
-        stageNumberTextStyle: stageNumberTextStyle ?? this.stageNumberTextStyle,
-        stageTitleTextStyle: stageTitleTextStyle ?? this.stageTitleTextStyle);
-  }
-}
-
-const StageCardStyle _defaultStyle = const _DefaultStyle();
-
-class StageCard extends StatefulWidget {
-  final StageCardViewModel _viewModel;
-  final StageCardStyle _style;
-
-  StageCard(
-      {Key key,
-      @required StageCardViewModel viewModel,
-      StageCardStyle style = _defaultStyle})
-      : this._viewModel = viewModel,
-        this._style = style,
-        super(key: key);
-
-  @override
-  _StageCardState createState() => _StageCardState();
-}
-
-class _StageCardState extends State<StageCard> {
-  static RoundedButtonStyle _actionButtonStyle =
-      RoundedButtonStyle.defaultStyle().copyWith(
+  final RoundedButtonStyle actionButtonStyle = const RoundedButtonStyle(
     backgroundColor: Color(0xff24d900),
     borderRadius: BorderRadius.all(Radius.circular(16)),
-    edgePadding: EdgeInsets.only(left: 0, top: 10, right: 0, bottom: 0),
     buttonTextStyle: TextStyle(
         fontSize: 13, fontWeight: FontWeight.bold, color: Color(0xffffffff)),
     iconEdgePadding: 5,
     height: 45,
     width: double.infinity,
     buttonIconSize: null,
+    iconButtonColor: Color(0xFFFFFFFF),
+    buttonShape: BoxShape.rectangle,
+  );
+  final DogTagStyle stageTagStyle = const DogTagStyle(
+    backgroundColor: Color(0xff24d900),
+    titleTextStyle: TextStyle(
+        color: Color(0xffffffff), fontSize: 11, fontWeight: FontWeight.bold),
+    borderRadius: BorderRadius.all(Radius.circular(20.0)),
+    edgePadding: EdgeInsets.only(top: 8.5, right: 12, left: 12, bottom: 8),
+    maxLines: 1,
+    iconSize: 8,
+    spacing: 5.5,
   );
 
-  RoundedButtonStyle _revertActionButtonStyle = _actionButtonStyle.copyWith(
-    backgroundColor: Color(0xffe9eaf2),
-    buttonTextStyle: TextStyle(
-        fontSize: 13, fontWeight: FontWeight.bold, color: Color(0xff4c4e6e)),
-  );
+  const _DefaultStyle({
+    double cardCornerRadius,
+    Color cardBackgroundColor,
+    EdgeInsets cardContentPadding,
+    TextStyle stageNumberTextStyle,
+    TextStyle stageTitleTextStyle,
+    RoundedButtonStyle actionButtonStyle,
+    DogTagStyle stageTagStyle,
+  });
+}
 
-  @override
-  void initState() {
-    // TODO: implement initState
-    super.initState();
-  }
+const StageCardStyle _defaultStyle = const _DefaultStyle();
+
+class StageCard extends StatelessWidget {
+  static final int _maxLines = 1;
+  static final double _titleHeightSeparator = 2;
+  static final int _titleFlexValue = 3;
+  final StageCardViewModel _viewModel;
+  final StageCardStyle _style;
+
+  const StageCard({
+    Key key,
+    @required StageCardViewModel viewModel,
+    StageCardStyle style = _defaultStyle,
+  })  : this._viewModel = viewModel,
+        this._style = style,
+        super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(widget._style.cardCornerRadius),
-          color: widget._style.cardBackgroundColor),
+          borderRadius: BorderRadius.circular(_style.cardCornerRadius),
+          color: _style.cardBackgroundColor),
       child: Padding(
-        padding: widget._style.cardContentPadding,
+        padding: _style.cardContentPadding,
         child: Column(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: <Widget>[
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    Text(
-                      //TODO replace string by viewModel
-                      'Stage 2',
-                      style: widget._style.stageNumberTextStyle,
-                    ),
-                    SizedBox(
-                      height: 2,
-                    ),
-                    Text(
-                      //TODO replace string by viewModel
-                      'Planting',
-                      style: widget._style.stageTitleTextStyle,
-                    ),
-                  ],
+                Expanded(
+                  flex: _titleFlexValue,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(
+                        _viewModel.stageNumber,
+                        style: _style.stageNumberTextStyle,
+                        maxLines: _maxLines,
+                      ),
+                      SizedBox(
+                        height: _titleHeightSeparator,
+                      ),
+                      Text(
+                        _viewModel.stageTitle,
+                        style: _style.stageTitleTextStyle,
+                        maxLines: _maxLines,
+                      ),
+                    ],
+                  ),
                 ),
                 DogTag(
                   viewModel: DogTagViewModel(
-                    title: 'Complete',
-                  ),
-                  style: DogTagStyle.defaultStyle().copyWith(
-                    backgroundColor: Color(0xff24d900),
-                    titleTextStyle: TextStyle(
-                        color: Color(0xffffffff),
-                        fontSize: 11,
-                        fontWeight: FontWeight.bold),
-                  ),
+                      title: _viewModel.stageStatusTitle,
+                      icon: _viewModel.dogTagIcon),
+                  style: _style.stageTagStyle,
                 ),
               ],
             ),
             RoundedButton(
               viewModel: RoundedButtonViewModel(
-                  title: 'Revert to In Progress', onTap: () {}),
-              style: _actionButtonStyle,
+                  title: _viewModel.actionButtonText,
+                  onTap: _viewModel.actionButton),
+              style: _style.actionButtonStyle,
             )
           ],
         ),

--- a/lib/ui/common/stage_card.dart
+++ b/lib/ui/common/stage_card.dart
@@ -7,70 +7,70 @@ export 'package:farmsmart_flutter/ui/common/Dogtag.dart';
 export 'package:farmsmart_flutter/ui/common/roundedButton.dart';
 
 class StageCardViewModel {
-  String stageNumber;
-  String stageTitle;
-  String actionButtonText;
-  String stageStatusTitle;
-  Function actionButton;
-  IconData dogTagIcon;
+  String subtitle;
+  String title;
+  String actionText;
+  String statusTitle;
+  Function action;
+  IconData statusIcon;
 
   StageCardViewModel(
-      {this.stageNumber,
-      this.stageTitle,
-      this.actionButtonText,
-      this.stageStatusTitle,
-      this.actionButton,
-      this.dogTagIcon});
+      {this.subtitle,
+      this.title,
+      this.actionText,
+      this.statusTitle,
+      this.action,
+      this.statusIcon});
 }
 
 class StageCardStyle {
-  final double cardCornerRadius;
-  final Color cardBackgroundColor;
-  final EdgeInsets cardContentPadding;
-  final TextStyle stageNumberTextStyle;
-  final TextStyle stageTitleTextStyle;
+  final double cornerRadius;
+  final Color backgroundColor;
+  final EdgeInsets contentPadding;
+  final TextStyle subtitleTextStyle;
+  final TextStyle titleTextStyle;
   final RoundedButtonStyle actionButtonStyle;
-  final DogTagStyle stageTagStyle;
+  final DogTagStyle statusTagStyle;
 
   const StageCardStyle({
-    this.cardCornerRadius,
-    this.cardBackgroundColor,
-    this.cardContentPadding,
-    this.stageNumberTextStyle,
-    this.stageTitleTextStyle,
+    this.cornerRadius,
+    this.backgroundColor,
+    this.contentPadding,
+    this.subtitleTextStyle,
+    this.titleTextStyle,
     this.actionButtonStyle,
-    this.stageTagStyle,
+    this.statusTagStyle,
   });
 
   StageCardStyle copyWith(
-      {double cardCornerRadius,
-      Color cardBackgroundColor,
-      EdgeInsets cardContentPadding,
-      TextStyle stageNumberTextStyle,
-      TextStyle stageTitleTextStyle,
+      {double cornerRadius,
+      Color backgroundColor,
+      EdgeInsets contentPadding,
+      TextStyle subtitleTextStyle,
+      TextStyle titleTextStyle,
       RoundedButtonStyle actionButtonStyle,
-      DogTagStyle stageTagStyle}) {
+      DogTagStyle statusTagStyle}) {
     return StageCardStyle(
-        cardCornerRadius: cardCornerRadius ?? this.cardCornerRadius,
-        cardBackgroundColor: cardBackgroundColor ?? this.cardBackgroundColor,
-        cardContentPadding: cardContentPadding ?? this.cardContentPadding,
-        stageNumberTextStyle: stageNumberTextStyle ?? this.stageNumberTextStyle,
-        stageTitleTextStyle: stageTitleTextStyle ?? this.stageTitleTextStyle,
+        cornerRadius: cornerRadius ?? this.cornerRadius,
+        backgroundColor: backgroundColor ?? this.backgroundColor,
+        contentPadding: contentPadding ?? this.contentPadding,
+        subtitleTextStyle: subtitleTextStyle ?? this.subtitleTextStyle,
+        titleTextStyle: titleTextStyle ?? this.titleTextStyle,
         actionButtonStyle: actionButtonStyle ?? this.actionButtonStyle,
-        stageTagStyle: stageTagStyle ?? this.stageTagStyle);
+        statusTagStyle: statusTagStyle ?? this.statusTagStyle);
   }
 }
 
 class _DefaultStyle extends StageCardStyle {
-  final double cardCornerRadius = 20.0;
-  final Color cardBackgroundColor = const Color(0xFFf5f8fa);
-  final EdgeInsets cardContentPadding =
+  final double cornerRadius = 20.0;
+  final Color backgroundColor = const Color(0xFFf5f8fa);
+  final EdgeInsets contentPadding =
       const EdgeInsets.symmetric(horizontal: 24, vertical: 20);
-  final TextStyle stageNumberTextStyle = const TextStyle(
+  final TextStyle subtitleTextStyle = const TextStyle(
     color: Color(0xFF767690),
     fontSize: 15,
   );
-  final TextStyle stageTitleTextStyle = const TextStyle(
+  final TextStyle titleTextStyle = const TextStyle(
     color: Color(0xFF1A1B46),
     fontSize: 20,
     fontWeight: FontWeight.bold,
@@ -87,7 +87,7 @@ class _DefaultStyle extends StageCardStyle {
     iconButtonColor: Color(0xFFFFFFFF),
     buttonShape: BoxShape.rectangle,
   );
-  final DogTagStyle stageTagStyle = const DogTagStyle(
+  final DogTagStyle statusTagStyle = const DogTagStyle(
     backgroundColor: Color(0xff24d900),
     titleTextStyle: TextStyle(
         color: Color(0xffffffff), fontSize: 11, fontWeight: FontWeight.bold),
@@ -99,13 +99,13 @@ class _DefaultStyle extends StageCardStyle {
   );
 
   const _DefaultStyle({
-    double cardCornerRadius,
-    Color cardBackgroundColor,
-    EdgeInsets cardContentPadding,
-    TextStyle stageNumberTextStyle,
-    TextStyle stageTitleTextStyle,
+    double cornerRadius,
+    Color backgroundColor,
+    EdgeInsets contentPadding,
+    TextStyle subtitleTextStyle,
+    TextStyle titleTextStyle,
     RoundedButtonStyle actionButtonStyle,
-    DogTagStyle stageTagStyle,
+    DogTagStyle statusTagStyle,
   });
 }
 
@@ -130,10 +130,10 @@ class StageCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(_style.cardCornerRadius),
-          color: _style.cardBackgroundColor),
+          borderRadius: BorderRadius.circular(_style.cornerRadius),
+          color: _style.backgroundColor),
       child: Padding(
-        padding: _style.cardContentPadding,
+        padding: _style.contentPadding,
         child: Column(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: <Widget>[
@@ -147,16 +147,16 @@ class StageCard extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
                       Text(
-                        _viewModel.stageNumber,
-                        style: _style.stageNumberTextStyle,
+                        _viewModel.subtitle,
+                        style: _style.subtitleTextStyle,
                         maxLines: _maxLines,
                       ),
                       SizedBox(
                         height: _titleHeightSeparator,
                       ),
                       Text(
-                        _viewModel.stageTitle,
-                        style: _style.stageTitleTextStyle,
+                        _viewModel.title,
+                        style: _style.titleTextStyle,
                         maxLines: _maxLines,
                       ),
                     ],
@@ -164,16 +164,16 @@ class StageCard extends StatelessWidget {
                 ),
                 DogTag(
                   viewModel: DogTagViewModel(
-                      title: _viewModel.stageStatusTitle,
-                      icon: _viewModel.dogTagIcon),
-                  style: _style.stageTagStyle,
+                      title: _viewModel.statusTitle,
+                      icon: _viewModel.statusIcon),
+                  style: _style.statusTagStyle,
                 ),
               ],
             ),
             RoundedButton(
               viewModel: RoundedButtonViewModel(
-                  title: _viewModel.actionButtonText,
-                  onTap: _viewModel.actionButton),
+                  title: _viewModel.actionText,
+                  onTap: _viewModel.action),
               style: _style.actionButtonStyle,
             )
           ],

--- a/lib/ui/mockData/MockStageCardViewModel.dart
+++ b/lib/ui/mockData/MockStageCardViewModel.dart
@@ -1,0 +1,37 @@
+import 'package:farmsmart_flutter/ui/common/MockString.dart';
+import 'package:farmsmart_flutter/ui/common/stage_card.dart';
+
+class MockStageCardViewModel {
+  static StageCardViewModel buildWithText() {
+    return StageCardViewModel(
+        stageNumber: _mockStage.random(),
+        stageTitle: _mockTitle.random(),
+        stageStatus: StageStatus(
+          stage: Stage.complete,
+          stageStatusText: _mockStageStatus.random(),
+          actionText: 'Revert to In Progress',
+          actionButton: () {},
+        ));
+  }
+}
+
+MockString _mockTitle = MockString(library: [
+  "Preparation",
+  "Planting",
+  "Maintenance",
+  "Harvesting",
+  "Next Steps",
+]);
+
+MockString _mockStage = MockString(library: [
+  "Stage 1",
+  "Stage 2",
+  "Stage 3",
+  "Stage 4",
+]);
+
+MockString _mockStageStatus = MockString(library: [
+  "Complete",
+  "Upcoming",
+  "In Progress",
+]);

--- a/lib/ui/mockData/MockStageCardViewModel.dart
+++ b/lib/ui/mockData/MockStageCardViewModel.dart
@@ -5,52 +5,52 @@ import 'package:flutter/material.dart';
 class MockStageCardViewModel {
   static StageCardViewModel buildUpcomingState() {
     return StageCardViewModel(
-      stageNumber: _mockStage.random(),
-      stageTitle: _mockTitle.random(),
-      actionButton: () {},
-      actionButtonText: 'Begin Stage',
-      stageStatusTitle: 'Upcoming'
+      subtitle: _mockStage.random(),
+      title: _mockTitle.random(),
+      action: () {},
+      actionText: 'Begin Stage',
+      statusTitle: 'Upcoming'
     );
   }
 
   static StageCardViewModel buildInProgressState() {
     return StageCardViewModel(
-        stageNumber: _mockStage.random(),
-        stageTitle: _mockTitle.random(),
-        actionButton: () {},
-        actionButtonText: 'Mark as Complete',
-        stageStatusTitle: 'In Progress'
+        subtitle: _mockStage.random(),
+        title: _mockTitle.random(),
+        action: () {},
+        actionText: 'Mark as Complete',
+        statusTitle: 'In Progress'
     );
   }
 
   static StageCardViewModel buildCompleteState() {
     return StageCardViewModel(
-        stageNumber: _mockStage.random(),
-        stageTitle: _mockTitle.random(),
-        dogTagIcon: Icons.check,
-        actionButton: () {},
-        actionButtonText: 'Revert to In Progress',
-        stageStatusTitle: 'Complete'
+        subtitle: _mockStage.random(),
+        title: _mockTitle.random(),
+        statusIcon: Icons.check,
+        action: () {},
+        actionText: 'Revert to In Progress',
+        statusTitle: 'Complete'
     );
   }
 
   static StageCardViewModel buildRandom() {
     return StageCardViewModel(
-        stageNumber: _mockLargeStrings.random(),
-        stageTitle: _mockLargeStrings.random(),
-        actionButton: () {},
-        actionButtonText: _mockActionButtonText.random(),
-        stageStatusTitle: _mockStageStatus.random()
+        subtitle: _mockLargeStrings.random(),
+        title: _mockLargeStrings.random(),
+        action: () {},
+        actionText: _mockActionButtonText.random(),
+        statusTitle: _mockStageStatus.random()
     );
   }
 }
 
 MockString _mockTitle = MockString(library: [
-  "Preparation with large text ",
+  "Preparation ",
   "Planting with large text",
-  "Maintenance with large text",
-  "Harvesting with large text ",
-  "Next Step with large text",
+  "Maintenance med",
+  "Harvesting with ultra large text that shouldn't be visible at all",
+  "Next Step medium",
 ]);
 
 MockString _mockStage = MockString(library: [

--- a/lib/ui/mockData/MockStageCardViewModel.dart
+++ b/lib/ui/mockData/MockStageCardViewModel.dart
@@ -8,7 +8,7 @@ class MockStageCardViewModel {
       stageNumber: _mockStage.random(),
       stageTitle: _mockTitle.random(),
       actionButton: () {},
-      actionButtonText: _mockActionButtonText.random(),
+      actionButtonText: 'Revert to In Progress',
       stageStatusTitle: 'Upcoming'
     );
   }
@@ -18,7 +18,7 @@ class MockStageCardViewModel {
         stageNumber: _mockStage.random(),
         stageTitle: _mockTitle.random(),
         actionButton: () {},
-        actionButtonText: _mockActionButtonText.random(),
+        actionButtonText: 'Mark as Complete',
         stageStatusTitle: 'In Progress'
     );
   }
@@ -29,8 +29,18 @@ class MockStageCardViewModel {
         stageTitle: _mockTitle.random(),
         dogTagIcon: Icons.check,
         actionButton: () {},
-        actionButtonText: _mockActionButtonText.random(),
+        actionButtonText: 'Revert to In Progress',
         stageStatusTitle: 'Complete'
+    );
+  }
+
+  static StageCardViewModel buildRandom() {
+    return StageCardViewModel(
+        stageNumber: _mockLargeStrings.random(),
+        stageTitle: _mockLargeStrings.random(),
+        actionButton: () {},
+        actionButtonText: _mockActionButtonText.random(),
+        stageStatusTitle: _mockStageStatus.random()
     );
   }
 }
@@ -48,6 +58,11 @@ MockString _mockStage = MockString(library: [
   "Stage 2 ",
   "Stage 3 ",
   "Stage 4 ",
+]);
+
+MockString _mockLargeStrings = MockString(library: [
+  "Very large text to test the limits  ",
+  "Large text to test the limits limits limits limits ",
 ]);
 
 MockString _mockStageStatus = MockString(library: [

--- a/lib/ui/mockData/MockStageCardViewModel.dart
+++ b/lib/ui/mockData/MockStageCardViewModel.dart
@@ -1,33 +1,53 @@
 import 'package:farmsmart_flutter/ui/common/MockString.dart';
 import 'package:farmsmart_flutter/ui/common/stage_card.dart';
+import 'package:flutter/material.dart';
 
 class MockStageCardViewModel {
-  static StageCardViewModel buildWithText() {
+  static StageCardViewModel buildUpcomingState() {
+    return StageCardViewModel(
+      stageNumber: _mockStage.random(),
+      stageTitle: _mockTitle.random(),
+      actionButton: () {},
+      actionButtonText: _mockActionButtonText.random(),
+      stageStatusTitle: 'Upcoming'
+    );
+  }
+
+  static StageCardViewModel buildInProgressState() {
     return StageCardViewModel(
         stageNumber: _mockStage.random(),
         stageTitle: _mockTitle.random(),
-        stageStatus: StageStatus(
-          stage: Stage.complete,
-          stageStatusText: _mockStageStatus.random(),
-          actionText: 'Revert to In Progress',
-          actionButton: () {},
-        ));
+        actionButton: () {},
+        actionButtonText: _mockActionButtonText.random(),
+        stageStatusTitle: 'In Progress'
+    );
+  }
+
+  static StageCardViewModel buildCompleteState() {
+    return StageCardViewModel(
+        stageNumber: _mockStage.random(),
+        stageTitle: _mockTitle.random(),
+        dogTagIcon: Icons.check,
+        actionButton: () {},
+        actionButtonText: _mockActionButtonText.random(),
+        stageStatusTitle: 'Complete'
+    );
   }
 }
 
 MockString _mockTitle = MockString(library: [
-  "Preparation",
-  "Planting",
-  "Maintenance",
-  "Harvesting",
-  "Next Steps",
+  "Preparation with large text ",
+  "Planting with large text",
+  "Maintenance with large text",
+  "Harvesting with large text ",
+  "Next Step with large text",
 ]);
 
 MockString _mockStage = MockString(library: [
-  "Stage 1",
-  "Stage 2",
-  "Stage 3",
-  "Stage 4",
+  "Stage 1 ",
+  "Stage 2 ",
+  "Stage 3 ",
+  "Stage 4 ",
 ]);
 
 MockString _mockStageStatus = MockString(library: [
@@ -35,3 +55,10 @@ MockString _mockStageStatus = MockString(library: [
   "Upcoming",
   "In Progress",
 ]);
+
+MockString _mockActionButtonText = MockString(library: [
+  "Mark as Complete",
+  "Begin Stage",
+  "Revert to In Progress",
+]);
+

--- a/lib/ui/mockData/MockStageCardViewModel.dart
+++ b/lib/ui/mockData/MockStageCardViewModel.dart
@@ -8,7 +8,7 @@ class MockStageCardViewModel {
       stageNumber: _mockStage.random(),
       stageTitle: _mockTitle.random(),
       actionButton: () {},
-      actionButtonText: 'Revert to In Progress',
+      actionButtonText: 'Begin Stage',
       stageStatusTitle: 'Upcoming'
     );
   }

--- a/lib/ui/playground/data/playground_atom_datasource.dart
+++ b/lib/ui/playground/data/playground_atom_datasource.dart
@@ -1,19 +1,21 @@
 import 'package:farmsmart_flutter/data/bloc/article/ArticleDetailTransformer.dart';
 import 'package:farmsmart_flutter/data/bloc/article/ArticleListItemViewModelTransformer.dart';
 import 'package:farmsmart_flutter/data/repositories/article/implementation/MockArticlesRepository.dart';
+import 'package:farmsmart_flutter/ui/common/ActionSheetListItem.dart';
 import 'package:farmsmart_flutter/ui/common/DogTagStyles.dart';
-import 'package:farmsmart_flutter/ui/discover/HeroListItem.dart';
-import 'package:farmsmart_flutter/ui/discover/StandardListItem.dart';
 import 'package:farmsmart_flutter/ui/common/Dogtag.dart';
 import 'package:farmsmart_flutter/ui/common/roundedButton.dart';
+import 'package:farmsmart_flutter/ui/discover/HeroListItem.dart';
+import 'package:farmsmart_flutter/ui/discover/StandardListItem.dart';
+import 'package:farmsmart_flutter/ui/mockData/MockActionSheetViewModel.dart';
 import 'package:farmsmart_flutter/ui/mockData/MockDogTagViewModel.dart';
 import 'package:farmsmart_flutter/ui/mockData/MockRoundedButtonViewModel.dart';
-import 'package:farmsmart_flutter/ui/common/ActionSheetListItem.dart';
-import 'package:farmsmart_flutter/ui/mockData/MockActionSheetViewModel.dart';
-import 'package:farmsmart_flutter/ui/playground/playground_widget.dart';
-import 'package:flutter/widgets.dart';
-import 'package:flutter/material.dart';
 import 'package:farmsmart_flutter/ui/playground/data/playground_data_source.dart';
+import 'package:farmsmart_flutter/ui/playground/playground_widget.dart';
+import 'package:farmsmart_flutter/ui/common/stage_card.dart';
+import 'package:farmsmart_flutter/ui/mockData/MockStageCardViewModel.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 class PlayGroundAtomDataSource implements PlaygroundDataSource {
   @override
@@ -144,6 +146,15 @@ class PlayGroundAtomDataSource implements PlaygroundDataSource {
           from: MockArticle.build(),
         ),
       ),
+      PlaygroundWidget(
+        title: 'Stage Card',
+        child: Container(
+          height: 162,
+          child: StageCard(
+            viewModel: MockStageCardViewModel.buildCompleteState(),
+          ),
+        ),
+      )
     ];
   }
 }

--- a/lib/ui/playground/data/playground_stagecard_datasource.dart
+++ b/lib/ui/playground/data/playground_stagecard_datasource.dart
@@ -1,0 +1,42 @@
+import 'playground_data_source.dart';
+import 'package:flutter/widgets.dart';
+import 'package:farmsmart_flutter/ui/common/stage_card.dart';
+import 'package:farmsmart_flutter/ui/mockData/MockStageCardViewModel.dart';
+import 'package:farmsmart_flutter/ui/playground/styles/stage_card_styles.dart';
+
+class PlaygroundStageCardDataSource extends PlaygroundDataSource{
+  @override
+  List<Widget> getList() {
+    return [
+      Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: StageCard(
+          viewModel: MockStageCardViewModel.buildCompleteState(),
+          style: StageCardStyles.buildCompleteStageStyle(),
+        ),
+      ),
+      Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: StageCard(
+          viewModel: MockStageCardViewModel.buildInProgressState(),
+          style: StageCardStyles.buildInProgressStageStyle(),
+        ),
+      ),
+      Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: StageCard(
+          viewModel: MockStageCardViewModel.buildUpcomingState(),
+          style: StageCardStyles.builtUpcomingStageStyle(),
+        ),
+      ),
+      Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: StageCard(
+          viewModel: MockStageCardViewModel.buildRandom(),
+          style: StageCardStyles.builtUpcomingStageStyle(),
+        ),
+      ),
+    ];
+  }
+
+}

--- a/lib/ui/playground/data/playground_tasks_datasource.dart
+++ b/lib/ui/playground/data/playground_tasks_datasource.dart
@@ -7,6 +7,7 @@ import 'package:farmsmart_flutter/ui/common/carousel_view.dart';
 import 'package:farmsmart_flutter/ui/common/stage_card.dart';
 import 'package:farmsmart_flutter/ui/mockData/MockStageCardViewModel.dart';
 import 'package:farmsmart_flutter/ui/playground/data/playground_data_source.dart';
+import 'package:farmsmart_flutter/ui/playground/data/playground_stagecard_datasource.dart';
 import 'package:farmsmart_flutter/ui/playground/playground_widget.dart';
 import 'package:farmsmart_flutter/ui/playground/styles/stage_card_styles.dart';
 import 'package:farmsmart_flutter/ui/profitloss/ProfitLossHeader.dart';
@@ -96,36 +97,7 @@ class PlayGroundTasksDataSource implements PlaygroundDataSource {
         child: Container(
           height: 162,
           child: CarouselView(
-            children: <Widget>[
-              Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: StageCard(
-                  viewModel: MockStageCardViewModel.buildCompleteState(),
-                  style: StageCardStyles.getCompleteStageStyle(),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: StageCard(
-                  viewModel: MockStageCardViewModel.buildInProgressState(),
-                  style: StageCardStyles.getInProgressStageStyle(),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: StageCard(
-                  viewModel: MockStageCardViewModel.buildUpcomingState(),
-                  style: StageCardStyles.getUpcomingStageStyle(),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: StageCard(
-                  viewModel: MockStageCardViewModel.buildRandom(),
-                  style: StageCardStyles.getUpcomingStageStyle(),
-                ),
-              ),
-            ],
+            children: PlaygroundStageCardDataSource().getList(),
           ),
         ),
       ),

--- a/lib/ui/playground/data/playground_tasks_datasource.dart
+++ b/lib/ui/playground/data/playground_tasks_datasource.dart
@@ -3,10 +3,8 @@ import 'package:farmsmart_flutter/data/repositories/article/implementation/MockA
 import 'package:farmsmart_flutter/ui/discover/ArticleList.dart';
 import 'package:farmsmart_flutter/ui/common/ActionSheet.dart';
 import 'package:farmsmart_flutter/ui/mockData/MockActionSheetViewModel.dart';
-import 'package:farmsmart_flutter/ui/playground/data/playground_atom_datasource.dart';
 import 'package:farmsmart_flutter/ui/common/carousel_view.dart';
 import 'package:farmsmart_flutter/ui/common/stage_card.dart';
-import 'package:farmsmart_flutter/ui/mockData/MockActionSheetViewModel.dart';
 import 'package:farmsmart_flutter/ui/mockData/MockStageCardViewModel.dart';
 import 'package:farmsmart_flutter/ui/playground/data/playground_data_source.dart';
 import 'package:farmsmart_flutter/ui/playground/playground_widget.dart';

--- a/lib/ui/playground/data/playground_tasks_datasource.dart
+++ b/lib/ui/playground/data/playground_tasks_datasource.dart
@@ -99,17 +99,33 @@ class PlayGroundTasksDataSource implements PlaygroundDataSource {
           height: 162,
           child: CarouselView(
             children: <Widget>[
-              StageCard(
-                viewModel: MockStageCardViewModel.buildCompleteState(),
-                style: StageCardStyles.getCompleteStageStyle(),
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: StageCard(
+                  viewModel: MockStageCardViewModel.buildCompleteState(),
+                  style: StageCardStyles.getCompleteStageStyle(),
+                ),
               ),
-              StageCard(
-                viewModel: MockStageCardViewModel.buildInProgressState(),
-                style: StageCardStyles.getInProgressStageStyle(),
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: StageCard(
+                  viewModel: MockStageCardViewModel.buildInProgressState(),
+                  style: StageCardStyles.getInProgressStageStyle(),
+                ),
               ),
-              StageCard(
-                viewModel: MockStageCardViewModel.buildUpcomingState(),
-                style: StageCardStyles.getUpcomingStageStyle(),
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: StageCard(
+                  viewModel: MockStageCardViewModel.buildUpcomingState(),
+                  style: StageCardStyles.getUpcomingStageStyle(),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: StageCard(
+                  viewModel: MockStageCardViewModel.buildRandom(),
+                  style: StageCardStyles.getUpcomingStageStyle(),
+                ),
               ),
             ],
           ),
@@ -117,8 +133,11 @@ class PlayGroundTasksDataSource implements PlaygroundDataSource {
       ),
       PlaygroundWidget(
         title: 'TASK FARM-278 Card view',
-        child: StageCard(
-          viewModel: MockStageCardViewModel.buildCompleteState(),
+        child: Container(
+          height: 162,
+          child: StageCard(
+            viewModel: MockStageCardViewModel.buildCompleteState(),
+          ),
         ),
       ),
       /* Template

--- a/lib/ui/playground/data/playground_tasks_datasource.dart
+++ b/lib/ui/playground/data/playground_tasks_datasource.dart
@@ -4,13 +4,17 @@ import 'package:farmsmart_flutter/ui/discover/ArticleList.dart';
 import 'package:farmsmart_flutter/ui/common/ActionSheet.dart';
 import 'package:farmsmart_flutter/ui/mockData/MockActionSheetViewModel.dart';
 import 'package:farmsmart_flutter/ui/playground/data/playground_atom_datasource.dart';
+import 'package:farmsmart_flutter/ui/common/carousel_view.dart';
+import 'package:farmsmart_flutter/ui/common/stage_card.dart';
+import 'package:farmsmart_flutter/ui/mockData/MockActionSheetViewModel.dart';
+import 'package:farmsmart_flutter/ui/mockData/MockStageCardViewModel.dart';
 import 'package:farmsmart_flutter/ui/playground/data/playground_data_source.dart';
 import 'package:farmsmart_flutter/ui/playground/playground_widget.dart';
+import 'package:farmsmart_flutter/ui/playground/styles/stage_card_styles.dart';
 import 'package:farmsmart_flutter/ui/profitloss/ProfitLossHeader.dart';
 import 'package:farmsmart_flutter/ui/profitloss/ProfitLossListItem.dart';
 import 'package:farmsmart_flutter/ui/profitloss/mockRepositoryTryout/MockTransactionRepository.dart';
 import 'package:flutter/material.dart';
-import 'package:farmsmart_flutter/ui/playground/data/playground_data_source.dart';
 import 'package:flutter/widgets.dart';
 
 import '../playground_view.dart';
@@ -82,6 +86,41 @@ class PlayGroundTasksDataSource implements PlaygroundDataSource {
                           style: ActionSheetStyle.defaultStyle()))),
             ],
           )),
+      PlaygroundWidget(
+          title: 'FARM-355 Generic Action Sheet - Type 4',
+          child: Container(
+              height: 350,
+              child: ActionSheet(
+                  viewModel: MockActionSheetViewModel.buildWithCheckBox(),
+                  style: ActionSheetStyle.defaultStyle()))),
+      PlaygroundWidget(
+        title: 'TASK FARM-278 State carousel view',
+        child: Container(
+          height: 162,
+          child: CarouselView(
+            children: <Widget>[
+              StageCard(
+                viewModel: MockStageCardViewModel.buildCompleteState(),
+                style: StageCardStyles.getCompleteStageStyle(),
+              ),
+              StageCard(
+                viewModel: MockStageCardViewModel.buildInProgressState(),
+                style: StageCardStyles.getInProgressStageStyle(),
+              ),
+              StageCard(
+                viewModel: MockStageCardViewModel.buildUpcomingState(),
+                style: StageCardStyles.getUpcomingStageStyle(),
+              ),
+            ],
+          ),
+        ),
+      ),
+      PlaygroundWidget(
+        title: 'TASK FARM-278 Card view',
+        child: StageCard(
+          viewModel: MockStageCardViewModel.buildCompleteState(),
+        ),
+      ),
       /* Template
       PlaygroundWidget(
         title: '#TASK NAME#',

--- a/lib/ui/playground/data/playground_tasks_datasource.dart
+++ b/lib/ui/playground/data/playground_tasks_datasource.dart
@@ -129,15 +129,6 @@ class PlayGroundTasksDataSource implements PlaygroundDataSource {
           ),
         ),
       ),
-      PlaygroundWidget(
-        title: 'TASK FARM-278 Card view',
-        child: Container(
-          height: 162,
-          child: StageCard(
-            viewModel: MockStageCardViewModel.buildCompleteState(),
-          ),
-        ),
-      ),
       /* Template
       PlaygroundWidget(
         title: '#TASK NAME#',

--- a/lib/ui/playground/data/playground_tasks_datasource.dart
+++ b/lib/ui/playground/data/playground_tasks_datasource.dart
@@ -10,6 +10,7 @@ import 'package:farmsmart_flutter/ui/profitloss/ProfitLossHeader.dart';
 import 'package:farmsmart_flutter/ui/profitloss/ProfitLossListItem.dart';
 import 'package:farmsmart_flutter/ui/profitloss/mockRepositoryTryout/MockTransactionRepository.dart';
 import 'package:flutter/material.dart';
+import 'package:farmsmart_flutter/ui/playground/data/playground_data_source.dart';
 import 'package:flutter/widgets.dart';
 
 import '../playground_view.dart';

--- a/lib/ui/playground/playground_widget.dart
+++ b/lib/ui/playground/playground_widget.dart
@@ -1,13 +1,19 @@
 import 'package:flutter/widgets.dart';
 
-class PlaygroundWidget extends StatelessWidget {
-  PlaygroundWidget({Key key, this.title, this.child});
-
+class PlaygroundWidget extends StatefulWidget {
   final String title;
   final Widget child;
 
+  PlaygroundWidget({Key key, this.title, this.child});
+
+  @override
+  _PlaygroundWidgetState createState() => _PlaygroundWidgetState();
+}
+
+class _PlaygroundWidgetState extends State<PlaygroundWidget> {
   @override
   Widget build(BuildContext context) {
-    return child;
+    return widget.child;
   }
 }
+

--- a/lib/ui/playground/playground_widget.dart
+++ b/lib/ui/playground/playground_widget.dart
@@ -1,19 +1,13 @@
 import 'package:flutter/widgets.dart';
 
-class PlaygroundWidget extends StatefulWidget {
+class PlaygroundWidget extends StatelessWidget {
   final String title;
   final Widget child;
 
   PlaygroundWidget({Key key, this.title, this.child});
 
   @override
-  _PlaygroundWidgetState createState() => _PlaygroundWidgetState();
-}
-
-class _PlaygroundWidgetState extends State<PlaygroundWidget> {
-  @override
   Widget build(BuildContext context) {
-    return widget.child;
+    return child;
   }
 }
-

--- a/lib/ui/playground/playground_widget.dart
+++ b/lib/ui/playground/playground_widget.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/widgets.dart';
 
 class PlaygroundWidget extends StatelessWidget {
+  PlaygroundWidget({Key key, this.title, this.child});
+
   final String title;
   final Widget child;
-
-  PlaygroundWidget({Key key, this.title, this.child});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/ui/playground/styles/stage_card_styles.dart
+++ b/lib/ui/playground/styles/stage_card_styles.dart
@@ -13,9 +13,9 @@ class StageCardStyles {
           ),
         ),
         stageTagStyle: _defaultDogTagStyle.copyWith(
-          backgroundColor: Color(0xffffffff),
+          backgroundColor: Color(0xffb7b8c9),
           titleTextStyle: TextStyle(
-              color: Color(0xffb7b8c9),
+              color: Color(0xffffffff),
               fontSize: 11,
               fontWeight: FontWeight.bold),
         ));
@@ -95,7 +95,7 @@ class StageCardStyles {
     titleTextStyle: TextStyle(
         color: Color(0xffffffff), fontSize: 11, fontWeight: FontWeight.bold),
     borderRadius: BorderRadius.all(Radius.circular(20.0)),
-    edgePadding: EdgeInsets.only(top: 8.5, right: 12, left: 12, bottom: 8),
+    edgePadding: EdgeInsets.only(top: 8, right: 12, left: 12, bottom: 8),
     maxLines: 1,
     iconSize: 8,
     spacing: 5.5,

--- a/lib/ui/playground/styles/stage_card_styles.dart
+++ b/lib/ui/playground/styles/stage_card_styles.dart
@@ -2,7 +2,7 @@ import 'package:farmsmart_flutter/ui/common/stage_card.dart';
 import 'package:flutter/widgets.dart';
 
 class StageCardStyles {
-  static StageCardStyle getUpcomingStageStyle() {
+  static StageCardStyle builtUpcomingStageStyle() {
     return _defaultStageCardStyle.copyWith(
         actionButtonStyle: _defaultRoundedButtonStyle.copyWith(
           backgroundColor: Color(0xff24d900),
@@ -12,7 +12,7 @@ class StageCardStyles {
             color: Color(0xffffffff),
           ),
         ),
-        stageTagStyle: _defaultDogTagStyle.copyWith(
+        statusTagStyle: _defaultDogTagStyle.copyWith(
           backgroundColor: Color(0xffb7b8c9),
           titleTextStyle: TextStyle(
               color: Color(0xffffffff),
@@ -21,7 +21,7 @@ class StageCardStyles {
         ));
   }
 
-  static StageCardStyle getInProgressStageStyle() {
+  static StageCardStyle buildInProgressStageStyle() {
     return _defaultStageCardStyle.copyWith(
         actionButtonStyle: _defaultRoundedButtonStyle.copyWith(
           backgroundColor: Color(0xff24d900),
@@ -31,7 +31,7 @@ class StageCardStyles {
             color: Color(0xffffffff),
           ),
         ),
-        stageTagStyle: _defaultDogTagStyle.copyWith(
+        statusTagStyle: _defaultDogTagStyle.copyWith(
           backgroundColor: Color(0xffffba00),
           titleTextStyle: TextStyle(
               color: Color(0xffffffff),
@@ -40,7 +40,7 @@ class StageCardStyles {
         ));
   }
 
-  static StageCardStyle getCompleteStageStyle() {
+  static StageCardStyle buildCompleteStageStyle() {
     return _defaultStageCardStyle.copyWith(
         actionButtonStyle: _defaultRoundedButtonStyle.copyWith(
           backgroundColor: Color(0xffe9eaf2),
@@ -50,7 +50,7 @@ class StageCardStyles {
             color: Color(0xff4c4e6e),
           ),
         ),
-        stageTagStyle: _defaultDogTagStyle.copyWith(
+        statusTagStyle: _defaultDogTagStyle.copyWith(
           backgroundColor: Color(0xff24d900),
           titleTextStyle: TextStyle(
               color: Color(0xffffffff),
@@ -60,21 +60,21 @@ class StageCardStyles {
   }
 
   static StageCardStyle _defaultStageCardStyle = StageCardStyle(
-    cardCornerRadius: 20.0,
-    cardBackgroundColor: Color(0xFFf5f8fa),
-    cardContentPadding:
+    cornerRadius: 20.0,
+    backgroundColor: Color(0xFFf5f8fa),
+    contentPadding:
         const EdgeInsets.symmetric(horizontal: 24, vertical: 20),
-    stageNumberTextStyle: TextStyle(
+    subtitleTextStyle: TextStyle(
       color: Color(0xFF767690),
       fontSize: 15,
     ),
-    stageTitleTextStyle: TextStyle(
+    titleTextStyle: TextStyle(
       color: Color(0xFF1A1B46),
       fontSize: 20,
       fontWeight: FontWeight.bold,
     ),
     actionButtonStyle: _defaultRoundedButtonStyle,
-    stageTagStyle: _defaultDogTagStyle,
+    statusTagStyle: _defaultDogTagStyle,
   );
 
   static RoundedButtonStyle _defaultRoundedButtonStyle = RoundedButtonStyle(
@@ -92,12 +92,13 @@ class StageCardStyles {
 
   static DogTagStyle _defaultDogTagStyle = DogTagStyle(
     backgroundColor: Color(0xff24d900),
+    iconColor: Color(0xffffffff),
     titleTextStyle: TextStyle(
         color: Color(0xffffffff), fontSize: 11, fontWeight: FontWeight.bold),
     borderRadius: BorderRadius.all(Radius.circular(14.0)),
     edgePadding: EdgeInsets.only(top: 8, right: 12, left: 12, bottom: 8),
     maxLines: 1,
-    iconSize: 8,
+    iconSize: 9,
     spacing: 5.5,
   );
 }

--- a/lib/ui/playground/styles/stage_card_styles.dart
+++ b/lib/ui/playground/styles/stage_card_styles.dart
@@ -1,0 +1,103 @@
+import 'package:farmsmart_flutter/ui/common/stage_card.dart';
+import 'package:flutter/widgets.dart';
+
+class StageCardStyles {
+  static StageCardStyle getUpcomingStageStyle() {
+    return _defaultStageCardStyle.copyWith(
+        actionButtonStyle: _defaultRoundedButtonStyle.copyWith(
+          backgroundColor: Color(0xff24d900),
+          buttonTextStyle: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.bold,
+            color: Color(0xffffffff),
+          ),
+        ),
+        stageTagStyle: _defaultDogTagStyle.copyWith(
+          backgroundColor: Color(0xffffffff),
+          titleTextStyle: TextStyle(
+              color: Color(0xffb7b8c9),
+              fontSize: 11,
+              fontWeight: FontWeight.bold),
+        ));
+  }
+
+  static StageCardStyle getInProgressStageStyle() {
+    return _defaultStageCardStyle.copyWith(
+        actionButtonStyle: _defaultRoundedButtonStyle.copyWith(
+          backgroundColor: Color(0xff24d900),
+          buttonTextStyle: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.bold,
+            color: Color(0xffffffff),
+          ),
+        ),
+        stageTagStyle: _defaultDogTagStyle.copyWith(
+          backgroundColor: Color(0xffffba00),
+          titleTextStyle: TextStyle(
+              color: Color(0xffffffff),
+              fontSize: 11,
+              fontWeight: FontWeight.bold),
+        ));
+  }
+
+  static StageCardStyle getCompleteStageStyle() {
+    return _defaultStageCardStyle.copyWith(
+        actionButtonStyle: _defaultRoundedButtonStyle.copyWith(
+          backgroundColor: Color(0xffe9eaf2),
+          buttonTextStyle: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.bold,
+            color: Color(0xff4c4e6e),
+          ),
+        ),
+        stageTagStyle: _defaultDogTagStyle.copyWith(
+          backgroundColor: Color(0xff24d900),
+          titleTextStyle: TextStyle(
+              color: Color(0xffffffff),
+              fontSize: 11,
+              fontWeight: FontWeight.bold),
+        ));
+  }
+
+  static StageCardStyle _defaultStageCardStyle = StageCardStyle(
+    cardCornerRadius: 20.0,
+    cardBackgroundColor: Color(0xFFf5f8fa),
+    cardContentPadding:
+        const EdgeInsets.symmetric(horizontal: 24, vertical: 20),
+    stageNumberTextStyle: TextStyle(
+      color: Color(0xFF767690),
+      fontSize: 15,
+    ),
+    stageTitleTextStyle: TextStyle(
+      color: Color(0xFF1A1B46),
+      fontSize: 20,
+      fontWeight: FontWeight.bold,
+    ),
+    actionButtonStyle: _defaultRoundedButtonStyle,
+    stageTagStyle: _defaultDogTagStyle,
+  );
+
+  static RoundedButtonStyle _defaultRoundedButtonStyle = RoundedButtonStyle(
+    backgroundColor: Color(0xff24d900),
+    borderRadius: BorderRadius.all(Radius.circular(16)),
+    buttonTextStyle: TextStyle(
+        fontSize: 13, fontWeight: FontWeight.bold, color: Color(0xffffffff)),
+    iconEdgePadding: 5,
+    height: 45,
+    width: double.infinity,
+    buttonIconSize: null,
+    iconButtonColor: Color(0xFFFFFFFF),
+    buttonShape: BoxShape.rectangle,
+  );
+
+  static DogTagStyle _defaultDogTagStyle = DogTagStyle(
+    backgroundColor: Color(0xff24d900),
+    titleTextStyle: TextStyle(
+        color: Color(0xffffffff), fontSize: 11, fontWeight: FontWeight.bold),
+    borderRadius: BorderRadius.all(Radius.circular(20.0)),
+    edgePadding: EdgeInsets.only(top: 8.5, right: 12, left: 12, bottom: 8),
+    maxLines: 1,
+    iconSize: 8,
+    spacing: 5.5,
+  );
+}

--- a/lib/ui/playground/styles/stage_card_styles.dart
+++ b/lib/ui/playground/styles/stage_card_styles.dart
@@ -8,7 +8,7 @@ class StageCardStyles {
           backgroundColor: Color(0xff24d900),
           buttonTextStyle: TextStyle(
             fontSize: 13,
-            fontWeight: FontWeight.bold,
+            fontWeight: FontWeight.w500,
             color: Color(0xffffffff),
           ),
         ),
@@ -27,7 +27,7 @@ class StageCardStyles {
           backgroundColor: Color(0xff24d900),
           buttonTextStyle: TextStyle(
             fontSize: 13,
-            fontWeight: FontWeight.bold,
+            fontWeight: FontWeight.w500,
             color: Color(0xffffffff),
           ),
         ),
@@ -46,7 +46,7 @@ class StageCardStyles {
           backgroundColor: Color(0xffe9eaf2),
           buttonTextStyle: TextStyle(
             fontSize: 13,
-            fontWeight: FontWeight.bold,
+            fontWeight: FontWeight.w500,
             color: Color(0xff4c4e6e),
           ),
         ),
@@ -79,7 +79,7 @@ class StageCardStyles {
 
   static RoundedButtonStyle _defaultRoundedButtonStyle = RoundedButtonStyle(
     backgroundColor: Color(0xff24d900),
-    borderRadius: BorderRadius.all(Radius.circular(16)),
+    borderRadius: BorderRadius.all(Radius.circular(8)),
     buttonTextStyle: TextStyle(
         fontSize: 13, fontWeight: FontWeight.bold, color: Color(0xffffffff)),
     iconEdgePadding: 5,
@@ -94,7 +94,7 @@ class StageCardStyles {
     backgroundColor: Color(0xff24d900),
     titleTextStyle: TextStyle(
         color: Color(0xffffffff), fontSize: 11, fontWeight: FontWeight.bold),
-    borderRadius: BorderRadius.all(Radius.circular(20.0)),
+    borderRadius: BorderRadius.all(Radius.circular(14.0)),
     edgePadding: EdgeInsets.only(top: 8, right: 12, left: 12, bottom: 8),
     maxLines: 1,
     iconSize: 8,


### PR DESCRIPTION
[FARM-278]

**NOTE**: I need to rebase @isaacmartinezimv pending PR to add the color of the icon on the DogTag

#### 📲 What

Created the stage card view for the stage crop detail screen. Also created a pager to add these stage cards.

#### 🤔 Why
		
We need it on the crop detail screen to show all the crop stages
		
#### 🛠 How
		
Created a new Widget StageCard, also created a CarouselView that can have a list of widgets with swipe pagination

#### 👀 See
		
![crop stage gif](https://user-images.githubusercontent.com/23307893/61027552-ca9a5c80-a3b6-11e9-8474-683d52c4a9b7.gif)

		 
#### ✅ Acceptance criteria

- [ ] Design Review for UI with BA completed. 
- [ ] Manually tested and verified on Android device/emulator (min. Lollipop 5.1)
- [ ] Showcase video / automation test
- [ ] Passing all tests
- [ ] Rebased/merged with latest changes from development and re-tested
- [ ] Removed unsed comments. TODOs must have JIRA for future work.

#### Coding Standards Checklist
- [ ] unit tests 80% coverage on testable code (functions, methods, class)
- [ ] (Architecture) redux state, reducers, actions, middleware defined under lib/redux
- [ ] ui elements defined under lib/ui. 
- [ ] Strings ready for localisation (e.g. defined in lib/utils/strings.dart)
- [ ] Assets (images/icons path) defined in lib/utils/assets.dart
- [ ] Colors defined in lib/utils/colors.dart
- [ ] Dimensions (ie margins padding) defined in lib/utils/dimens.dart
- [ ] TextStyles defined in lib/utils/styles.dart

Recommended Style Guide: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo

#### 🕵️‍♂️ How to test

Notes for QA

#### Reviewers

@farmsmart/amido @farmsmart/wamf
