### PR TITLE
Feature/farm 436 sectioned list

### DIFF
--- a/lib/data/bloc/StaticViewModelProvider.dart
+++ b/lib/data/bloc/StaticViewModelProvider.dart
@@ -1,0 +1,23 @@
+
+
+import 'dart:async';
+
+import 'package:farmsmart_flutter/data/bloc/ViewModelProvider.dart';
+
+class StaticViewModelProvider<T> implements ViewModelProvider<T> {
+
+  final T _viewModel;
+
+  StaticViewModelProvider(T viewModel) : _viewModel = viewModel;
+
+  @override
+  T initial() {
+    return _viewModel;
+  }
+
+  @override
+  StreamController<T> observe() {
+    return null;
+  }
+
+}

--- a/lib/data/bloc/article/ArticleDetailTransformer.dart
+++ b/lib/data/bloc/article/ArticleDetailTransformer.dart
@@ -32,12 +32,13 @@ class ArticleDetailViewModelTransformer
   final _dateFormatter = DateFormat(_Strings.publishedDateFormat);
   @override
   ArticleDetailViewModel transform({ArticleEntity from}) {
+    ArticleImageProvider imageProvider = (from.images != null) ? ArticleImageProvider(from) : null;
     ArticleDetailViewModel viewModel = ArticleDetailViewModel(
       LoadingStatus.SUCCESS,
       from.title,
       _subtitle(article: from),
       Intl.message(_Strings.relatedTitle),
-      ArticleImageProvider(from),
+      imageProvider,
       from.content,
       buildArticleDeeplink(from.id),
     );

--- a/lib/data/model/mock/MockArticle.dart
+++ b/lib/data/model/mock/MockArticle.dart
@@ -21,6 +21,21 @@ class MockArticle extends MockEntity<ArticleEntity> {
     entity.images = MockImageEntityCollection();
     return entity;
   }
+  
+  ArticleEntity buildStage() {
+    final entity = ArticleEntity(
+      id: mockPlainText.identifier(),
+      content: mockRichTextNoImage.random(),
+      status: Status.PUBLISHED,
+      summary: mockPlainText.random(),
+      title: mockTitleText.random(),
+      published: _mockDate.randomYearAgo(),
+    );
+    entity.related = MockArticleEntityCollection();
+    entity.images = null;
+    return entity;
+  }
+
 }
 
 MockArticle _articleBuilder = MockArticle();

--- a/lib/data/model/mock/MockEntity.dart
+++ b/lib/data/model/mock/MockEntity.dart
@@ -12,7 +12,7 @@ abstract class MockEntity<T> {
 }
 
 class MockEntityCollection<T> implements EntityCollection<T> {
-  final _delay = Duration(seconds: 1);
+  final _delay = Duration(milliseconds: 200);
   final MockEntity<T> _builder;
 
   MockEntityCollection(this._builder);

--- a/lib/data/model/mock/MockStage.dart
+++ b/lib/data/model/mock/MockStage.dart
@@ -17,7 +17,7 @@ class MockStage extends MockEntity<NewStageEntity> {
 
   NewStageEntity build() {
       final start = _mockDate.randomMonthAgo();
-      return NewStageEntity(id: _identifiers.identifier(), article: _articleBuilder.build(), started: start, ended: null);
+      return NewStageEntity(id: _identifiers.identifier(), article: _articleBuilder.buildStage(), started: start, ended: null);
   }
 
   //LH here we generate valid stage sequence starting and ending at the input dates, and ending at the input stage
@@ -40,7 +40,7 @@ class MockStage extends MockEntity<NewStageEntity> {
           startDate = null;
           endDate = null;
         }
-        stages.add(NewStageEntity(id: _identifiers.identifier(), article: _articleBuilder.build(), started: startDate, ended: endDate));
+        stages.add(NewStageEntity(id: _identifiers.identifier(), article: _articleBuilder.buildStage(), started: startDate, ended: endDate));
         current = next;
       }
     return stages;

--- a/lib/data/repositories/MockStrings.dart
+++ b/lib/data/repositories/MockStrings.dart
@@ -15,6 +15,56 @@ MockString mockPlainText = MockString(library: [
   "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
 ]);
 
+MockString mockRichTextNoImage = MockString(library: [
+  """<p><abbr>ABBR</abbr>, <acronym>ACRONYM</acronym> or <span style="border-bottom: 1px dotted">inline style</span></p>
+<p><b>B</b>, <strong>STRONG</strong> or <span style="font-weight: bold">inline style</span></p>
+<p><em>EM</em>, <i>I</i> or <span style="font-style: italic">inline style</span></p>
+<p><u>U</u> or <span style="text-decoration: underline">inline</span> <span style="border-bottom: 1px">style</span></p>
+<p><span style="color: #ff0000">Red</span>, <span style="color: #00ff00">green</span>, <span style="color: #0000ff">blue</span></p>
+<p>
+  <span style="text-decoration: line-through">
+    <span style="text-decoration: overline">
+      <span style="text-decoration: underline">
+        All decorations...
+        <span style="text-decoration: none">and none</span>
+      </span>
+    </span>
+  </span>
+</p>""",
+  """<ul>
+  <li>One</li>
+  <li>Two</li>
+  <li>Three</li>
+</ul>""",
+  """<ol>
+  <li>One</li>
+  <li>
+    Two
+    <ul>
+      <li>2.1</li>
+      <li>
+        2.2
+        <ul>
+          <li>2.2.1</li>
+          <li>2.2.2</li>
+        </ul>
+      </li>
+      <li>2.3</li>
+    </ul>
+  </li>
+ 
+ <li>Three</li>
+  <li>Four</li>
+  <li>Five</li>
+  <li>Six</li>
+  <li>Seven</li>
+  <li>Eight</li>
+  <li>Nine</li>
+  <li>Ten</li>
+  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nibh quam, sodales in sollicitudin ut, scelerisque non sapien. Nam nec mi malesuada libero euismod tincidunt sit amet mattis ipsum. Etiam dapibus sem ac accumsan elementum. Vivamus mattis at diam ac pellentesque. Sed id eros condimentum, dignissim risus id, semper enim. Etiam tempor mauris id lorem fringilla, dapibus feugiat enim placerat. In hac habitasse platea dictumst. Nam est felis, accumsan et sapien ac, molestie convallis sapien. Vivamus ligula sapien, ultrices quis nisl ac, blandit hendrerit massa. Maecenas eleifend, nisi eget commodo mollis, elit magna pellentesque odio, sit amet auctor quam nibh vel purus. Integer ultricies lacinia ipsum, in tincidunt erat finibus eget.</li>
+</ol>"""
+]);
+
 MockString mockRichText = MockString(library: [
   """<p><abbr>ABBR</abbr>, <acronym>ACRONYM</acronym> or <span style="border-bottom: 1px dotted">inline style</span></p>
 <p><b>B</b>, <strong>STRONG</strong> or <span style="font-weight: bold">inline style</span></p>

--- a/lib/data/repositories/article/implementation/MockArticlesRepository.dart
+++ b/lib/data/repositories/article/implementation/MockArticlesRepository.dart
@@ -7,7 +7,7 @@ MockArticle _articleBuilder = MockArticle();
 
 class MockArticlesRepository implements ArticleRepositoryInterface {
   final _articles;
-  final _delay = Duration(seconds: 1);
+  final _delay = Duration(milliseconds: 200);
   final _streamEventCount = 50;
 
   MockArticlesRepository({int articleCount = 1000})

--- a/lib/data/repositories/plot/implementation/MockPlotRepository.dart
+++ b/lib/data/repositories/plot/implementation/MockPlotRepository.dart
@@ -1,7 +1,5 @@
 
 import 'dart:async';
-
-import 'package:farmsmart_flutter/data/bloc/plot/StageBusinessLogic.dart';
 import 'package:farmsmart_flutter/data/model/EntityCollectionInterface.dart';
 import 'package:farmsmart_flutter/data/model/NewStageEntity.dart';
 import 'package:farmsmart_flutter/data/model/PlotEntity.dart';
@@ -15,7 +13,6 @@ import '../PlotRepositoryInterface.dart';
 final _plotBuilder = MockPlotEntity();
 
 class MockPlotRepository implements PlotRepositoryInterface {
-  final StageBusinessLogic _stageLogic =  StageBusinessLogic() ;
   final _plotStreamController =  StreamController<List<PlotEntity>>.broadcast(); 
   List<PlotEntity> _plots = [];
 

--- a/lib/ui/common/SectionListView.dart
+++ b/lib/ui/common/SectionListView.dart
@@ -1,0 +1,71 @@
+
+
+import 'package:flutter/material.dart';
+
+abstract class ListViewSection {
+    IndexedWidgetBuilder itemBuilder();
+    int length();
+}
+
+class _SectionPosition {
+  final int offset;
+  final ListViewSection section;
+
+  _SectionPosition(this.offset, this.section);
+  int relativeOffset(int absoluteOffset) {
+      return absoluteOffset - offset;
+  }
+}
+
+class SectionedListView extends StatelessWidget implements ListViewSection {
+  final ScrollPhysics _physics;
+  final bool _shrinkWrap;
+  final List<_SectionPosition> _sectionPositions;
+  final int _allItemCount;
+
+  SectionedListView._(this._sectionPositions,this._allItemCount, this._shrinkWrap, this._physics);
+
+  factory SectionedListView({@required List<ListViewSection> sections, ScrollPhysics physics = const ScrollPhysics(), bool shrinkWrap = true}) {
+    int allItemCount = 0;
+    final sectionPositions = sections.map((section) {
+        int offset = allItemCount;
+        allItemCount += section.length();
+        return _SectionPosition(offset, section);
+    }).toList();
+    return  SectionedListView._(sectionPositions,allItemCount,shrinkWrap,physics);
+  }
+
+  _SectionPosition sectionForIndex(int index) {
+    for (var sectionPosition in _sectionPositions.reversed) {
+       if (sectionPosition.relativeOffset(index) >= 0){
+         return sectionPosition;
+       }
+    }
+    return null;
+  }
+
+  @override
+  IndexedWidgetBuilder itemBuilder() {
+    return (context, index) {
+        final sectionPosition = sectionForIndex(index);
+        final sectionBuilder = sectionPosition.section.itemBuilder(); 
+        return sectionBuilder(context, sectionPosition.relativeOffset(index));
+    };
+  }
+
+  @override
+  int length() {
+    return _allItemCount;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      physics: _physics,
+      shrinkWrap: _shrinkWrap,
+      itemCount: length(),
+      itemBuilder: itemBuilder(),
+    );
+  }
+
+}

--- a/lib/ui/common/headerAndFooterListView.dart
+++ b/lib/ui/common/headerAndFooterListView.dart
@@ -1,3 +1,4 @@
+import 'package:farmsmart_flutter/ui/common/SectionListView.dart';
 import 'package:flutter/material.dart';
 
 /* 
@@ -5,57 +6,56 @@ Simple Widget to add header and footer elements to a list of elements
 It should ensure elements are built as needed and not the whole list.
 It hides the data offsetting complexity 
 */
-class HeaderAndFooterListView {
-  static Widget builder(
-      {@required int itemCount,
-      @required IndexedWidgetBuilder itemBuilder,
-      ScrollPhysics physics,
-      bool shrinkWrap = false,
-      Widget header,
-      Widget footer}) {
-    final headerPresent = (header != null);
-    final footerPresent = (footer != null);
-    final empty  = <Widget>[];
-    final headers = headerPresent ? [header] : empty;
-    final footers = footerPresent ? [footer] : empty;
-    return _builder(
-        itemCount: itemCount,
-        itemBuilder: itemBuilder,
-        physics: physics,
-        shrinkWrap: shrinkWrap,
-        headers: headers,
-        footers: footers);
-  }
+class HeaderAndFooterListView extends StatelessWidget implements ListViewSection {
+
+  final IndexedWidgetBuilder _containedItemBuilder;
+  final int _containedItemCount;
+  final List<Widget> _headers;
+  final List<Widget> _footers;
+  final ScrollPhysics _physics;
+  final bool _shrinkWrap;
+
+  HeaderAndFooterListView({IndexedWidgetBuilder itemBuilder, int itemCount = 0, List<Widget> headers = const [], List<Widget>  footers = const [], ScrollPhysics physics, bool shrinkWrap}) : this._containedItemBuilder = itemBuilder, 
+  this._containedItemCount = itemCount, this._headers = headers, this._footers = footers, this._physics = physics, this._shrinkWrap = shrinkWrap;
 
   /*
   Modeling with lists for headers and footers simplifys the logic here and may be useful in the future
   For now we only expose the single header and footer functionality
   */
-  static Widget _builder(
-      { @required int itemCount,
-      @required IndexedWidgetBuilder itemBuilder,
-      ScrollPhysics physics,
-      bool shrinkWrap = false,
-      List<Widget> headers = const <Widget>[],
-      List<Widget> footers = const <Widget>[]}) {
-    final int totalItemCount = headers.length + itemCount + footers.length;
+
+    @override
+  Widget build(BuildContext context) {
     return ListView.builder(
-      physics: physics,
-      shrinkWrap: shrinkWrap,
-      itemCount: totalItemCount,
-      itemBuilder: (context, index) {
-        int itemIndex = index - headers.length; // index in terms of items
-        int footerIndex = itemIndex - itemCount;  // index in terms of footer elements
-        if (index < headers.length) {
-          return headers[index];
-        }
-        else if (itemIndex < itemCount) {
-          return itemBuilder(context, itemIndex);
-        }
-        else {
-          return footers[footerIndex];
-        }
-      },
+      physics: _physics,
+      shrinkWrap: _shrinkWrap,
+      itemCount: length(),
+      itemBuilder: itemBuilder(),
     );
   }
+
+  @override
+  int length() {
+    int headerLength =  _headers.length;
+    int footerLength =  _footers.length;
+    return headerLength + _containedItemCount + footerLength;
+  }
+
+  @override
+  IndexedWidgetBuilder itemBuilder() {
+    return (context, index) {
+        int itemCount = _containedItemCount;
+        int itemIndex = index - _headers.length; // index in terms of items
+        int footerIndex = itemIndex - itemCount;  // index in terms of footer elements
+        if (index < _headers.length) {
+          return _headers[index];
+        }
+        else if (itemIndex < itemCount) {
+          return _containedItemBuilder(context, itemIndex);
+        }
+        else {
+          return _footers[footerIndex];
+        }
+      };
+  }
+
 }

--- a/lib/ui/discover/ArticleDetail.dart
+++ b/lib/ui/discover/ArticleDetail.dart
@@ -1,5 +1,6 @@
 import 'package:farmsmart_flutter/model/loading_status.dart';
 import 'package:farmsmart_flutter/ui/common/ContextualAppBar.dart';
+import 'package:farmsmart_flutter/ui/common/SectionListView.dart';
 import 'package:farmsmart_flutter/ui/common/headerAndFooterListView.dart';
 import 'package:farmsmart_flutter/ui/common/network_image_from_future.dart';
 import 'package:farmsmart_flutter/ui/discover/viewModel/ArticleDetailViewModel.dart';
@@ -69,11 +70,12 @@ class _DefaultStyle implements ArticleDetailStyle {
   const _DefaultStyle();
 }
 
-class ArticleDetail extends StatelessWidget {
+class ArticleDetail extends StatelessWidget implements ListViewSection {
   final ArticleDetailViewModel _viewModel;
   final ArticleDetailStyle _style;
+  List<ArticleListItemViewModel> _releatedViewModels = [];
 
-  const ArticleDetail(
+  ArticleDetail(
       {Key key,
       ArticleDetailViewModel viewModel,
       ArticleDetailStyle style = const _DefaultStyle()})
@@ -83,34 +85,33 @@ class ArticleDetail extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _build(context: context, viewModel: _viewModel, style: _style);
-  }
-
-  Widget _build(
-      {BuildContext context,
-      ArticleDetailViewModel viewModel,
-      ArticleDetailStyle style}) {
-    var releatedViewModels = [];
-    final loadingWidget = Container(
-        child: CircularProgressIndicator(), alignment: Alignment.center);
-
     return FutureBuilder(
-      future: viewModel.getRelated(),
+      future: _viewModel.getRelated(),
       builder: (BuildContext context,
           AsyncSnapshot<List<ArticleListItemViewModel>> relatedArticles) {
         if (relatedArticles.hasData) {
-          releatedViewModels = relatedArticles.data;
+          _releatedViewModels = relatedArticles.data;
         }
-        final footer = (viewModel.loadingStatus == LoadingStatus.LOADING)
-            ? loadingWidget
-            : null;
         return Scaffold(
           appBar: _buildAppBar(context),
           body: Container(
-            child: HeaderAndFooterListView.builder(
-                itemCount: releatedViewModels.length,
+            child: _content(),
+          ),
+        );
+      },
+    );
+  }
+
+  HeaderAndFooterListView _content() {
+     final loadingWidget = Container(
+        child: CircularProgressIndicator(), alignment: Alignment.center);
+    final footer = (_viewModel.loadingStatus == LoadingStatus.LOADING)
+            ? loadingWidget
+            : null;
+      return HeaderAndFooterListView(
+                itemCount: _releatedViewModels.length,
                 itemBuilder: (BuildContext context, int index) {
-                  final viewModel = releatedViewModels[index];
+                  final viewModel = _releatedViewModels[index];
                   return StandardListItem(
                     viewModel: viewModel,
                     onTap: () => _tappedListItem(
@@ -119,13 +120,18 @@ class ArticleDetail extends StatelessWidget {
                 },
                 physics: ScrollPhysics(),
                 shrinkWrap: true,
-                header: buildHeader(
-                    context, releatedViewModels.isNotEmpty),
-                footer: footer),
-          ),
-        );
-      },
-    );
+                headers: [buildHeader(_releatedViewModels.isNotEmpty)],
+                footers: [footer]);
+  } 
+
+  @override
+  itemBuilder() {
+    return _content().itemBuilder();
+  }
+
+  @override
+  int length() {
+    return _content().length();
   }
 
   void _share() async {
@@ -139,7 +145,7 @@ class ArticleDetail extends StatelessWidget {
     ).build(context);
   }
 
-  Widget buildHeader(BuildContext context, bool relatedTitle) {
+  Widget buildHeader(bool relatedTitle) {
     final topWidgets = [
       _buildTitle(),
       _buildArticlePublishingDate(),

--- a/lib/ui/discover/ArticleList.dart
+++ b/lib/ui/discover/ArticleList.dart
@@ -124,12 +124,11 @@ class ArticleList extends StatelessWidget {
   }
 
   Widget _buildSuccess(BuildContext context, ArticleListViewModel viewModel) {
-    return HeaderAndFooterListView.builder(
-        itemCount: viewModel.articleListItemViewModels.length,
+    return HeaderAndFooterListView(itemCount: viewModel.articleListItemViewModels.length,
         itemBuilder:
             bodyListBuilder(viewModels: viewModel.articleListItemViewModels),
         physics: ScrollPhysics(),
         shrinkWrap: true,
-        header: buildHeader(viewModel: viewModel));
+        headers: [buildHeader(viewModel: viewModel)]);
   }
 }

--- a/lib/ui/myplot/PlotDetail.dart
+++ b/lib/ui/myplot/PlotDetail.dart
@@ -1,7 +1,9 @@
 import 'package:farmsmart_flutter/data/bloc/ViewModelProvider.dart';
 import 'package:farmsmart_flutter/data/repositories/image/implementation/MockImageEntity.dart';
 import 'package:farmsmart_flutter/ui/common/ContextualAppBar.dart';
+import 'package:farmsmart_flutter/ui/common/SectionListView.dart';
 import 'package:farmsmart_flutter/ui/common/carousel_view.dart';
+import 'package:farmsmart_flutter/ui/common/headerAndFooterListView.dart';
 import 'package:farmsmart_flutter/ui/common/stage_card.dart';
 import 'package:farmsmart_flutter/ui/discover/ArticleDetail.dart';
 import 'package:farmsmart_flutter/ui/myplot/PlotListItem.dart';
@@ -25,7 +27,7 @@ class _DefaultStyle implements PlotDetailStyle {
 class PlotDetail extends StatefulWidget {
   final ViewModelProvider<PlotDetailViewModel> _viewModelProvider;
   final PlotDetailStyle _style;
-
+  ArticleDetail _articleDetail;
   PlotDetail(
       {Key key,
       ViewModelProvider<PlotDetailViewModel> provider,
@@ -75,12 +77,14 @@ class _PlotDetailState extends State<PlotDetail> {
                 initialPage: _selectedStage,
                 onPageChange: _pageChanged,
               ));
-          final article = ArticleDetail(viewModel: articleViewModel)
-              .buildHeader(context, false);
+          widget._articleDetail = ArticleDetail(viewModel: articleViewModel);
+
+          final topSection = HeaderAndFooterListView(headers: <Widget>[header, stages],);
+          final sectionedList = SectionedListView(sections: [topSection, widget._articleDetail],);
 
           return Scaffold(
               appBar: _buildAppBar(context),
-              body: ListView(children: <Widget>[header, stages, article]));
+              body: sectionedList);
         });
   }
 

--- a/lib/ui/myplot/PlotDetail.dart
+++ b/lib/ui/myplot/PlotDetail.dart
@@ -1,11 +1,12 @@
 import 'package:farmsmart_flutter/data/bloc/ViewModelProvider.dart';
-import 'package:farmsmart_flutter/data/repositories/image/implementation/MockImageEntity.dart';
+
 import 'package:farmsmart_flutter/ui/common/ContextualAppBar.dart';
 import 'package:farmsmart_flutter/ui/common/SectionListView.dart';
 import 'package:farmsmart_flutter/ui/common/carousel_view.dart';
 import 'package:farmsmart_flutter/ui/common/headerAndFooterListView.dart';
 import 'package:farmsmart_flutter/ui/common/stage_card.dart';
 import 'package:farmsmart_flutter/ui/discover/ArticleDetail.dart';
+import 'package:farmsmart_flutter/ui/discover/viewModel/ArticleListItemViewModel.dart';
 import 'package:farmsmart_flutter/ui/myplot/PlotListItem.dart';
 import 'package:farmsmart_flutter/ui/myplot/viewmodel/PlotDetailViewModel.dart';
 import 'package:flutter/material.dart';
@@ -65,11 +66,11 @@ class _PlotDetailState extends State<PlotDetail> {
               title: viewModel.title,
               detail: viewModel.detailText,
               progress: viewModel.progress,
-              imageProvider: MockImageEntity().build().urlProvider);
+              imageProvider: viewModel.imageProvider);
           final articleViewModel =
               viewModel.stageArticleViewModels[_selectedStage];
           final header = PlotListItem()
-              .buildListItem(viewModel: headerViewModel, onTap: null);
+              .buildListItem(viewModel: headerViewModel, onTap: null); //TODO: add navigate to crop details
           final stages = Container(
               height: widget._style.stageSectionHeight,
               child: CarouselView(
@@ -77,14 +78,19 @@ class _PlotDetailState extends State<PlotDetail> {
                 initialPage: _selectedStage,
                 onPageChange: _pageChanged,
               ));
-          widget._articleDetail = ArticleDetail(viewModel: articleViewModel);
 
+          
+          widget._articleDetail = ArticleDetail(viewModel: articleViewModel, showHeader: false,);
           final topSection = HeaderAndFooterListView(headers: <Widget>[header, stages],);
-          final sectionedList = SectionedListView(sections: [topSection, widget._articleDetail],);
 
-          return Scaffold(
-              appBar: _buildAppBar(context),
-              body: sectionedList);
+          return FutureBuilder(
+                future: widget._articleDetail.fetchReleated(),
+                builder: (BuildContext context,
+                AsyncSnapshot<List<ArticleListItemViewModel>> relatedArticles) {
+                  final sectionedList = SectionedListView(sections: [topSection, widget._articleDetail],);
+                   return Scaffold(appBar: _buildAppBar(context), body: sectionedList);
+                
+          });
         });
   }
 

--- a/lib/ui/myplot/PlotList.dart
+++ b/lib/ui/myplot/PlotList.dart
@@ -99,7 +99,7 @@ class PlotList extends StatelessWidget {
   Widget _buildPage(BuildContext context, PlotListViewModel viewModel,
       PlotListStyle plotStyle, Function goToDetail) {
        
-    return HeaderAndFooterListView.builder(
+    return HeaderAndFooterListView(
         itemCount: viewModel.items.length,
         itemBuilder: (BuildContext context, int index) {
            final itemViewModel = viewModel.items[index];
@@ -109,8 +109,8 @@ class PlotList extends StatelessWidget {
         },
         physics: ScrollPhysics(),
         shrinkWrap: true,
-        header: _buildTitle(viewModel, plotStyle, context: context),
-        footer: Padding(
+        headers: [_buildTitle(viewModel, plotStyle, context: context)],
+        footers: [Padding(
           padding: plotStyle.largeButtonEdgePadding,
           child: Row(
             children: <Widget>[
@@ -123,7 +123,7 @@ class PlotList extends StatelessWidget {
               ),
             ],
           ),
-        ));
+        )]);
   }
 
   Widget _buildTitle(PlotListViewModel viewModel, PlotListStyle myPlotStyle,

--- a/lib/ui/profitloss/ProfitLossList.dart
+++ b/lib/ui/profitloss/ProfitLossList.dart
@@ -81,7 +81,7 @@ class _ProfitLossState extends State<ProfitLossPage> {
 
   Widget _buildPage(BuildContext context, ProfitLossListViewModel viewModel,
       ProfitLossStyle profitStyle) {
-    return HeaderAndFooterListView.builder(
+    return HeaderAndFooterListView(
         itemCount: viewModel.transactions.length,
         itemBuilder: (BuildContext context, int index) {
           return ProfitLossListItem(
@@ -90,13 +90,13 @@ class _ProfitLossState extends State<ProfitLossPage> {
         },
         physics: ScrollPhysics(),
         shrinkWrap: true,
-        header: ProfitLossHeader(
+        headers: [ProfitLossHeader(
             viewModel: ProfitLossHeaderViewModel(
                 viewModel.title, viewModel.detailText),
-            style: ProfitLossHeaderStyle.defaultStyle()),
-        footer: SizedBox(
+            style: ProfitLossHeaderStyle.defaultStyle())],
+        footers: [SizedBox(
           height: profitStyle.bottomEdgePadding,
-        ));
+        )]);
   }
 
   Widget _buildPageWithFloatingButton(BuildContext context,


### PR DESCRIPTION
[FARM-436 - Sectioned list]

#### 📲 What

A system to reuse the datasource of the article in other views.
A sectioned list can add list datasources together. A sectioned list itself can be a section, so you can add sectioned lists together.

#### 🤔 Why
		
To ensure lists are rendered efficiently and only have the widgets that are on screen.
		
#### 🛠 How
		
There is a simple interface you must implement to become a ListSection. once you are a list section you can be added to a sectioned list. sectioned lists implement the list section interface themselves. so can be added as sections in other sectioned lists (so you can add them together).

#### 👀 See
		
Screenshots / external resources
		 
#### ✅ Acceptance criteria

Recommended Style Guide: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo

#### 🕵️‍♂️ How to test

Notes for QA

Implemented in the plot detail screen, the article and repeated article are added to the plot details content.
#### Reviewers

@farmsmart/amido @farmsmart/wamf
