### PR TITLE
[Integration] Integrated user profile screen on new navigator

### DIFF
--- a/lib/ui/home.dart
+++ b/lib/ui/home.dart
@@ -8,8 +8,10 @@ import 'package:farmsmart_flutter/farmsmart_localizations.dart';
 import 'package:farmsmart_flutter/ui/bottombar/persistent_bottom_navigation_bar.dart';
 import 'package:farmsmart_flutter/ui/bottombar/tab_navigator.dart';
 import 'package:farmsmart_flutter/ui/discover/ArticleList.dart';
+import 'package:farmsmart_flutter/ui/mockData/MockUserProfileViewModel.dart';
 import 'package:farmsmart_flutter/ui/playground/data/playground_datasource_impl.dart';
 import 'package:farmsmart_flutter/ui/playground/playground_view.dart';
+import 'package:farmsmart_flutter/ui/profile/UserProfile.dart';
 import 'package:flutter/material.dart';
 
 import 'myplot/PlotList.dart';
@@ -78,8 +80,7 @@ class Home extends StatelessWidget {
         _Constants.communityIcon,
       ),
       _buildTabNavigatorWithCircleImageWidget(
-        //TODO Add profile screen
-        Text('Profile'),
+        _buildUserProfile(),
       ),
       _buildTabNavigator(
         _buildPlayground(),
@@ -112,6 +113,12 @@ class Home extends StatelessWidget {
             title: localizations.communityTab,
             repository: repositoryProvider.getArticleRepository(),
             group: ArticleCollectionGroup.chatGroups));
+  }
+
+  _buildUserProfile() {
+    return UserProfile(
+      viewModel: MockUserProfileViewModel.build(),
+    );
   }
 
   _buildPlayground() {

--- a/lib/ui/mockData/MockUserProfileViewModel.dart
+++ b/lib/ui/mockData/MockUserProfileViewModel.dart
@@ -103,14 +103,10 @@ List<String> _mockActionIcon = [
 
 MockString _mockImage = MockString(library: [
   "https://i.pinimg.com/originals/29/01/c9/2901c94b5a24c2f69d827e1755b5257e.jpg",
-  "https://occ-0-1722-1723.1.nflxso.net/art/d2938/a54bf5710e24e03aed993f1597454a46699d2938.jpg",
-  "https://www.flower-pepper.com/wp-content/uploads/2016/10/Kermit-the-Frog-by-Bartholomew-300x378.jpg",
   "https://vignette.wikia.nocookie.net/rugratseries/images/1/1a/Tommy.jpg/revision/latest?cb=20110202050218",
+  "https://www.flower-pepper.com/wp-content/uploads/2016/10/Kermit-the-Frog-by-Bartholomew-300x378.jpg",
 ]);
 
 MockString _mockUserName = MockString(library: [
-  "Name",
-  "Mininame",
   "Ireti Kuta",
-  "Longer User Name",
 ]);

--- a/lib/ui/profile/UserProfile.dart
+++ b/lib/ui/profile/UserProfile.dart
@@ -159,12 +159,14 @@ class UserProfile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      child: Column(
-        children: <Widget>[
-          _buildHeader(context),
-          _buildItemList(),
-        ],
+    return SafeArea(
+      child: SingleChildScrollView(
+        child: Column(
+          children: <Widget>[
+            _buildHeader(context),
+            _buildItemList(),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
[Integrate User Profile on new navigator]

#### 📲 What

User profile accessible thought bottom navigation bar.

#### 🤔 Why
		
Because the user needs to see his details.
		
#### 🛠 How
		
Using the WAMF Flutter code style

#### 👀 See
		
![userprofile](https://user-images.githubusercontent.com/34380229/62200627-19b82980-b386-11e9-9931-a98ac0bb4dbb.gif)
		 
#### ✅ Acceptance criteria

- [ ] Design Review for UI with BA completed. 
- [x] Manually tested and verified on Android device/emulator (min. Lollipop 5.1)
- [ ] Showcase video / automation test
- [ ] Passing all tests
- [ ] Rebased/merged with latest changes from development and re-tested
- [ ] Removed unsed comments. TODOs must have JIRA for future work.

#### Coding Standards Checklist
- [ ] unit tests 80% coverage on testable code (functions, methods, class)
- [ ] (Architecture) redux state, reducers, actions, middleware defined under lib/redux
- [ ] ui elements defined under lib/ui. 
- [ ] Strings ready for localisation (e.g. defined in lib/utils/strings.dart)
- [ ] Assets (images/icons path) defined in lib/utils/assets.dart
- [ ] Colors defined in lib/utils/colors.dart
- [ ] Dimensions (ie margins padding) defined in lib/utils/dimens.dart
- [ ] TextStyles defined in lib/utils/styles.dart

Recommended Style Guide: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo


#### Reviewers

@farmsmart/amido @farmsmart/wamf
