### PR TITLE
[FARM-310] Integrate general Alert My plot

### DIFF
--- a/lib/model/bloc/plot/StageToStageCardViewModel.dart
+++ b/lib/model/bloc/plot/StageToStageCardViewModel.dart
@@ -7,23 +7,23 @@ import 'package:farmsmart_flutter/ui/playground/styles/stage_card_styles.dart';
 import 'package:intl/intl.dart';
 
 class _LocalisedStrings {
-  static stage() => 'Stage';
+  static stage() => Intl.message('Stage');
 
-  static inProgress() => 'In Progress';
+  static inProgress() => Intl.message('In Progress');
 
-  static upcoming() => 'Upcoming';
+  static upcoming() => Intl.message('Upcoming');
 
-  static complete() => 'Complete';
+  static complete() => Intl.message('Complete');
 
-  static completeAction() => 'Completed';
+  static completeAction() => Intl.message('Completed');
 
-  static revertAction() => 'Revert to In Progress';
+  static revertAction() => Intl.message('Revert to In Progress');
 
-  static readyAction() => 'Begin Stage';
+  static readyAction() => Intl.message('Begin Stage');
 
-  static upcomingAction() => 'Please complete previous';
+  static upcomingAction() => Intl.message('Please complete previous');
 
-  static inProgressAction() => 'Mark as complete';
+  static inProgressAction() => Intl.message('Mark as complete');
 
   static beginCropDialogTitle() => Intl.message('Begin crop');
 

--- a/lib/model/bloc/plot/StageToStageCardViewModel.dart
+++ b/lib/model/bloc/plot/StageToStageCardViewModel.dart
@@ -6,18 +6,44 @@ import 'package:farmsmart_flutter/ui/common/stage_card.dart';
 import 'package:farmsmart_flutter/ui/playground/styles/stage_card_styles.dart';
 import 'package:intl/intl.dart';
 
-class _Strings {
-  static final stage = "Stage";
+class _LocalisedStrings {
+  static stage() => 'Stage';
 
-  static final inProgress = "In Progress";
-  static final upcoming = "Upcoming";
-  static final complete = "Complete";
+  static inProgress() => 'In Progress';
 
-  static final completeAction = "Completed";
-  static final revertAction = "Revert to In Progress";
-  static final readyAction = "Begin Stage";
-  static final upcomingAction = "Please complete previous";
-  static final inProgressAction = "Mark as complete";
+  static upcoming() => 'Upcoming';
+
+  static complete() => 'Complete';
+
+  static completeAction() => 'Completed';
+
+  static revertAction() => 'Revert to In Progress';
+
+  static readyAction() => 'Begin Stage';
+
+  static upcomingAction() => 'Please complete previous';
+
+  static inProgressAction() => 'Mark as complete';
+
+  static beginCropDialogTitle() => Intl.message('Begin crop');
+
+  static markAsCompleteDialogTitle() => Intl.message('Mark as complete');
+
+  static completeCropTitle() => Intl.message('Complete crop');
+
+  static revertDialogTitle() => Intl.message('Revert crop');
+
+  static beginCropDialogDescription() =>
+      Intl.message('Are you sure you want to mark this stage as in progress?');
+
+  static markAsCompleteDialogDescription() =>
+      Intl.message('Are you sure you want to mark this stage as complete?');
+
+  static completeCropDialogDescription() =>
+      Intl.message('Are you sure you want to market this crop as complete?');
+
+  static revertDialogDescription() =>
+      Intl.message('Are you sure you want revert the stage status?');
 }
 
 class StageToStageCardViewModel
@@ -35,15 +61,18 @@ class StageToStageCardViewModel
   StageCardViewModel transform({NewStageEntity from}) {
     final stageNumber = _plot.stages.indexOf(from) + 1;
     final subtitle =
-        Intl.message(_Strings.stage) + " " + stageNumber.toString();
+        _LocalisedStrings.stage() + " " + stageNumber.toString();
     final status = _logic.status(from);
     return StageCardViewModel(
-        title: from.article.title,
-        subtitle: subtitle,
-        statusTitle: _statusTitle(status),
-        actionText: _actionTitle(status, from),
-        action: _action(status, from),
-        style: _cardStyle(status, from));
+      title: from.article.title,
+      subtitle: subtitle,
+      statusTitle: _statusTitle(status),
+      actionText: _actionTitle(status, from),
+      action: _action(status, from),
+      style: _cardStyle(status, from),
+      dialogTitle: _dialogTitle(status, from),
+      dialogDescription: _dialogDescription(status, from),
+    );
   }
 
   StageCardStyle _cardStyle(StageStatus status, NewStageEntity stage) {
@@ -64,17 +93,17 @@ class StageToStageCardViewModel
   String _actionTitle(StageStatus status, NewStageEntity stage) {
     switch (status) {
       case StageStatus.inProgress:
-        return Intl.message(_Strings.inProgressAction);
+        return _LocalisedStrings.inProgressAction();
         break;
       case StageStatus.complete:
         return _logic.canRevert(stage, _plot.stages)
-            ? Intl.message(_Strings.revertAction)
-            : Intl.message(_Strings.completeAction);
+            ? _LocalisedStrings.revertAction()
+            : _LocalisedStrings.completeAction();
         break;
       default:
         return _logic.canBegin(stage, _plot.stages)
-            ? Intl.message(_Strings.readyAction)
-            : Intl.message(_Strings.upcomingAction);
+            ? _LocalisedStrings.readyAction()
+            : _LocalisedStrings.upcomingAction();
     }
   }
 
@@ -92,13 +121,43 @@ class StageToStageCardViewModel
   String _statusTitle(StageStatus status) {
     switch (status) {
       case StageStatus.inProgress:
-        return Intl.message(_Strings.inProgress);
+        return _LocalisedStrings.inProgress();
         break;
       case StageStatus.complete:
-        return Intl.message(_Strings.complete);
+        return _LocalisedStrings.complete();
         break;
       default:
-        return Intl.message(_Strings.upcoming);
+        return _LocalisedStrings.upcoming();
     }
+  }
+
+  String _dialogTitle(StageStatus status, NewStageEntity stage) {
+    if (_logic.canBegin(stage, _plot.stages)) {
+      return _LocalisedStrings.beginCropDialogTitle();
+    } else if (_logic.canComplete(stage, _plot.stages)) {
+      if (stage == _plot.stages.last) {
+        return _LocalisedStrings.completeCropTitle();
+      } else {
+        return _LocalisedStrings.markAsCompleteDialogTitle();
+      }
+    } else if (_logic.canRevert(stage, _plot.stages)) {
+      return _LocalisedStrings.revertDialogTitle();
+    }
+    return null;
+  }
+
+  String _dialogDescription(StageStatus status, NewStageEntity stage) {
+    if (_logic.canBegin(stage, _plot.stages)) {
+      return _LocalisedStrings.beginCropDialogDescription();
+    } else if (_logic.canComplete(stage, _plot.stages)) {
+      if (stage == _plot.stages.last) {
+        return _LocalisedStrings.completeCropDialogDescription();
+      } else {
+        return _LocalisedStrings.markAsCompleteDialogDescription();
+      }
+    } else if (_logic.canRevert(stage, _plot.stages)) {
+      return _LocalisedStrings.revertDialogDescription();
+    }
+    return null;
   }
 }

--- a/lib/ui/common/stage_card.dart
+++ b/lib/ui/common/stage_card.dart
@@ -2,9 +2,18 @@ import 'package:farmsmart_flutter/ui/common/Dogtag.dart';
 import 'package:farmsmart_flutter/ui/common/roundedButton.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:intl/intl.dart';
+
+import 'Alert.dart';
 
 export 'package:farmsmart_flutter/ui/common/Dogtag.dart';
 export 'package:farmsmart_flutter/ui/common/roundedButton.dart';
+
+class _LocalisedStrings {
+  static cancel() => Intl.message('Cancel');
+
+  static confirm() => Intl.message('Confirm');
+}
 
 class StageCardViewModel {
   String subtitle;
@@ -13,14 +22,19 @@ class StageCardViewModel {
   String statusTitle;
   Function action;
   StageCardStyle style;
+  String dialogTitle;
+  String dialogDescription;
 
-  StageCardViewModel(
-      {this.subtitle,
-      this.title,
-      this.actionText,
-      this.statusTitle,
-      this.action,
-      this.style});
+  StageCardViewModel({
+    this.subtitle,
+    this.title,
+    this.actionText,
+    this.statusTitle,
+    this.action,
+    this.style,
+    this.dialogTitle,
+    this.dialogDescription,
+  });
 }
 
 class StageCardStyle {
@@ -41,18 +55,19 @@ class StageCardStyle {
     this.titleTextStyle,
     this.actionButtonStyle,
     this.statusTagStyle,
-    this.statusIcon
+    this.statusIcon,
   });
 
-  StageCardStyle copyWith(
-      {double cornerRadius,
-      Color backgroundColor,
-      EdgeInsets contentPadding,
-      TextStyle subtitleTextStyle,
-      TextStyle titleTextStyle,
-      RoundedButtonStyle actionButtonStyle,
-      DogTagStyle statusTagStyle,
-      IconData statusIcon}) {
+  StageCardStyle copyWith({
+    double cornerRadius,
+    Color backgroundColor,
+    EdgeInsets contentPadding,
+    TextStyle subtitleTextStyle,
+    TextStyle titleTextStyle,
+    RoundedButtonStyle actionButtonStyle,
+    DogTagStyle statusTagStyle,
+    IconData statusIcon,
+  }) {
     return StageCardStyle(
         cornerRadius: cornerRadius ?? this.cornerRadius,
         backgroundColor: backgroundColor ?? this.backgroundColor,
@@ -61,7 +76,7 @@ class StageCardStyle {
         titleTextStyle: titleTextStyle ?? this.titleTextStyle,
         actionButtonStyle: actionButtonStyle ?? this.actionButtonStyle,
         statusTagStyle: statusTagStyle ?? this.statusTagStyle,
-         statusIcon: statusIcon ?? this.statusIcon);
+        statusIcon: statusIcon ?? this.statusIcon);
   }
 }
 
@@ -168,8 +183,7 @@ class StageCard extends StatelessWidget {
                 ),
                 DogTag(
                   viewModel: DogTagViewModel(
-                      title: _viewModel.statusTitle,
-                      icon: _style.statusIcon),
+                      title: _viewModel.statusTitle, icon: _style.statusIcon),
                   style: _style.statusTagStyle,
                 ),
               ],
@@ -177,12 +191,32 @@ class StageCard extends StatelessWidget {
             RoundedButton(
               viewModel: RoundedButtonViewModel(
                   title: _viewModel.actionText,
-                  onTap: _viewModel.action),
+                  onTap: () {
+                    _buildAlertAction(context);
+                  }),
               style: _style.actionButtonStyle,
             )
           ],
         ),
       ),
     );
+  }
+
+  void _buildAlertAction(BuildContext context) {
+    if(_viewModel.action != null) {
+      Alert.present(
+        Alert(
+          viewModel: AlertViewModel(
+            cancelActionText: _LocalisedStrings.cancel(),
+            confirmActionText: _LocalisedStrings.confirm(),
+            titleText: _viewModel.dialogTitle,
+            detailText: _viewModel.dialogDescription,
+            isDestructive: false,
+            confirmAction: _viewModel.action,
+          ),
+        ),
+        context,
+      );
+    }
   }
 }

--- a/lib/ui/myplot/PlotDetail.dart
+++ b/lib/ui/myplot/PlotDetail.dart
@@ -1,7 +1,9 @@
 import 'package:farmsmart_flutter/model/bloc/ViewModelProvider.dart';
+import 'package:farmsmart_flutter/ui/article/ArticleDetail.dart';
+import 'package:farmsmart_flutter/ui/article/viewModel/ArticleListItemViewModel.dart';
 import 'package:farmsmart_flutter/ui/common/ActionSheet.dart';
 import 'package:farmsmart_flutter/ui/common/ActionSheetListItem.dart';
-
+import 'package:farmsmart_flutter/ui/common/Alert.dart';
 import 'package:farmsmart_flutter/ui/common/ContextualAppBar.dart';
 import 'package:farmsmart_flutter/ui/common/SectionListView.dart';
 import 'package:farmsmart_flutter/ui/common/ViewModelProviderBuilder.dart';
@@ -10,25 +12,34 @@ import 'package:farmsmart_flutter/ui/common/headerAndFooterListView.dart';
 import 'package:farmsmart_flutter/ui/common/stage_card.dart';
 import 'package:farmsmart_flutter/ui/crop/CropDetail.dart';
 import 'package:farmsmart_flutter/ui/crop/viewmodel/CropDetailViewModel.dart';
-import 'package:farmsmart_flutter/ui/article/ArticleDetail.dart';
-import 'package:farmsmart_flutter/ui/article/viewModel/ArticleListItemViewModel.dart';
 import 'package:farmsmart_flutter/ui/myplot/PlotListItem.dart';
 import 'package:farmsmart_flutter/ui/myplot/viewmodel/PlotDetailViewModel.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';
+
 import 'PlotDetailHeaderStyle.dart';
 
-class _Strings {
-  static final renameAction = "Rename Crop";
-  static final removeAction = "Delete Crop";
-  static final cancelAction = "Cancel";
+class _LocalisedStrings {
+  static renameAction() => Intl.message('Rename Crop');
+
+  static removeAction() => Intl.message('Delete Crop');
+
+  static cancelAction() => Intl.message('Cancel');
+
+  static confirm() => Intl.message('Confirm');
+
+  static removeDialogTitle() => Intl.message('Remove crop');
+
+  static removeDialogDescription() =>
+      Intl.message('Are you sure you want delete the crop?');
 }
 
 abstract class PlotDetailStyle {
   final TextStyle titleTextStyle;
   final double stageSectionHeight;
   final EdgeInsets cardPadding;
+
   const PlotDetailStyle(
       this.titleTextStyle, this.stageSectionHeight, this.cardPadding);
 }
@@ -37,6 +48,7 @@ class _DefaultStyle implements PlotDetailStyle {
   final TextStyle titleTextStyle = null;
   final double stageSectionHeight = 162;
   final EdgeInsets cardPadding = const EdgeInsets.all(8.0);
+
   const _DefaultStyle();
 }
 
@@ -44,6 +56,7 @@ class PlotDetail extends StatefulWidget {
   final ViewModelProvider<PlotDetailViewModel> _viewModelProvider;
   final PlotDetailStyle _style;
   ArticleDetail _articleDetail;
+
   PlotDetail(
       {Key key,
       ViewModelProvider<PlotDetailViewModel> provider,
@@ -151,8 +164,22 @@ class _PlotDetailState extends State<PlotDetail> {
   }
 
   void _removeAction(PlotDetailViewModel viewModel) {
-    viewModel.remove(); //TODO: add the confirm when ready
-    Navigator.of(context).pop();
+    Alert.present(
+      Alert(
+        viewModel: AlertViewModel(
+          cancelActionText: _LocalisedStrings.cancelAction(),
+          confirmActionText: _LocalisedStrings.confirm(),
+          titleText: _LocalisedStrings.removeDialogTitle(),
+          detailText: _LocalisedStrings.removeDialogDescription(),
+          confirmAction: () {
+            viewModel.remove();
+            Navigator.of(context).pop();
+          },
+          isDestructive: true,
+        ),
+      ),
+      context,
+    );
   }
 
   void _renameAction(PlotDetailViewModel viewModel) {
@@ -162,17 +189,17 @@ class _PlotDetailState extends State<PlotDetail> {
   ActionSheet _moreMenu(PlotDetailViewModel viewModel) {
     final actions = [
       ActionSheetListItemViewModel(
-          title: Intl.message(_Strings.renameAction),
+          title: _LocalisedStrings.renameAction(),
           type: ActionType.simple,
           onTap: () => _renameAction(viewModel)),
       ActionSheetListItemViewModel(
-          title: Intl.message(_Strings.removeAction),
+          title: _LocalisedStrings.removeAction(),
           type: ActionType.simple,
           isDestructive: true,
           onTap: () => _removeAction(viewModel)),
     ];
     final actionSheetViewModel =
-        ActionSheetViewModel(actions, Intl.message(_Strings.cancelAction));
+        ActionSheetViewModel(actions, _LocalisedStrings.cancelAction());
     return ActionSheet(
         viewModel: actionSheetViewModel,
         style: ActionSheetStyle.defaultStyle());


### PR DESCRIPTION
[FARM-310]

**NOTE: Missing the Delete profile Alert because it's in progress**

#### 📲 What

Added the general alert on
- Begin Crop
- Complete a stage
- Revert a stage
- Complete a crop
- Delete a crop

#### 🤔 Why
		
It's needed 
		
#### 🛠 How
		
Used the general Alert widget created before

#### 👀 See
		
![ezgif com-video-to-gif-4](https://user-images.githubusercontent.com/23307893/62478092-8aa67980-b7aa-11e9-937d-20f6425d315b.gif)

		 
#### ✅ Acceptance criteria

- [ ] Design Review for UI with BA completed. 
- [ ] Manually tested and verified on Android device/emulator (min. Lollipop 5.1)
- [ ] Showcase video / automation test
- [ ] Passing all tests
- [ ] Rebased/merged with latest changes from development and re-tested
- [ ] Removed unsed comments. TODOs must have JIRA for future work.

#### Coding Standards Checklist
- [ ] unit tests 80% coverage on testable code (functions, methods, class)
- [ ] (Architecture) redux state, reducers, actions, middleware defined under lib/redux
- [ ] ui elements defined under lib/ui. 
- [ ] Strings ready for localisation (e.g. defined in lib/utils/strings.dart)
- [ ] Assets (images/icons path) defined in lib/utils/assets.dart
- [ ] Colors defined in lib/utils/colors.dart
- [ ] Dimensions (ie margins padding) defined in lib/utils/dimens.dart
- [ ] TextStyles defined in lib/utils/styles.dart

Recommended Style Guide: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo

#### 🕵️‍♂️ How to test

Notes for QA

#### Reviewers

@farmsmart/amido @farmsmart/wamf
