### PR TITLE
[FARM-454] Fix image overlay color when selected

### DIFF
--- a/lib/ui/recommendations/recommendation_card/recommendation_card.dart
+++ b/lib/ui/recommendations/recommendation_card/recommendation_card.dart
@@ -32,6 +32,7 @@ class RecommendationCardStyle {
   final EdgeInsets contentPadding;
   final BoxDecoration rightActionBoxDecoration;
   final Color overlayColor;
+  final Color addedOverlayColor;
   final double overlayIconHeight;
   final double overlayIconWidth;
   final String overlayIcon;
@@ -51,6 +52,7 @@ class RecommendationCardStyle {
     this.overlayIconHeight,
     this.overlayIconWidth,
     this.overlayIcon,
+    this.addedOverlayColor,
   });
 
   RecommendationCardStyle copyWith({
@@ -65,6 +67,7 @@ class RecommendationCardStyle {
     EdgeInsets contentPadding,
     BoxDecoration rightBoxDecoration,
     Color overlayColor,
+    Color addedOverlayColor,
     double overlayIconHeight,
     double overlayIconWidth,
     String overlayIcon,
@@ -87,6 +90,7 @@ class RecommendationCardStyle {
       overlayIconHeight: overlayIconHeight ?? this.overlayIconHeight,
       overlayIconWidth: overlayIconWidth ?? this.overlayIconWidth,
       overlayIcon: overlayIcon ?? this.overlayIcon,
+      addedOverlayColor: addedOverlayColor ?? this.addedOverlayColor,
     );
   }
 }
@@ -117,6 +121,7 @@ class _DefaultStyle extends RecommendationCardStyle {
   final EdgeInsets contentPadding = const EdgeInsets.all(32.0);
 
   final Color overlayColor = const Color(0x1924d900);
+  final Color addedOverlayColor = const Color(0x3325df0c);
   final double overlayIconHeight = 54;
   final double overlayIconWidth = 54;
 
@@ -166,6 +171,7 @@ class _DefaultStyle extends RecommendationCardStyle {
     double overlayIconHeight,
     double overlayIconWidth,
     String overlayIcon,
+    Color addedOverlayColor,
   });
 }
 
@@ -215,7 +221,8 @@ class RecommendationCard extends StatelessWidget {
       overlayIcon: _style.overlayIcon,
       overlayIconHeight: _style.overlayIconHeight,
       overlayIconWidth: _style.overlayIconWidth,
-      overlayColor: _style.overlayColor,
+      overlayColor:
+          _viewModel.isAdded ? _style.addedOverlayColor : _style.overlayColor,
       showOverlayIcon: _viewModel.isAdded,
     );
   }
@@ -285,7 +292,8 @@ class RecommendationCard extends StatelessWidget {
           ),
           Expanded(
             child: Container(
-              decoration: _viewModel.isAdded ? _style.rightActionBoxDecoration : null,
+              decoration:
+                  _viewModel.isAdded ? _style.rightActionBoxDecoration : null,
               child: RoundedButtonStateful(
                 style: _style.rightActionButtonStyle,
                 viewModel: RoundedButtonStatefulViewModel(

--- a/lib/ui/recommendations/recommendation_card/recommendation_card_styles.dart
+++ b/lib/ui/recommendations/recommendation_card/recommendation_card_styles.dart
@@ -3,7 +3,6 @@ import 'package:flutter/widgets.dart';
 
 import 'recommendation_card.dart';
 
-
 class RecommendationCardStyles {
   static RecommendationCardStyle buildStyle() =>
       _defaultRecommendationCardStyle;
@@ -40,6 +39,7 @@ class RecommendationCardStyles {
       ),
       borderRadius: BorderRadius.circular(8),
     ),
+    addedOverlayColor: Color(0x3325df0c),
   );
 
   static RoundedButtonStatefulStyle _defaultLeftActionRoundedButtonStyle =

--- a/lib/ui/recommendations/recommendation_compact_card/recommendation_compact_card.dart
+++ b/lib/ui/recommendations/recommendation_compact_card/recommendation_compact_card.dart
@@ -34,6 +34,7 @@ class RecommendationCompactCardStyle {
   final double overlayIconHeight;
   final double overlayIconWidth;
   final String overlayIcon;
+  final Color addedOverlayColor;
 
   const RecommendationCompactCardStyle({
     this.titleTextStyle,
@@ -50,6 +51,7 @@ class RecommendationCompactCardStyle {
     this.overlayIconHeight,
     this.overlayIconWidth,
     this.overlayIcon,
+    this.addedOverlayColor,
   });
 
   RecommendationCompactCardStyle copyWith({
@@ -67,6 +69,7 @@ class RecommendationCompactCardStyle {
     double overlayIconHeight,
     double overlayIconWidth,
     String overlayIcon,
+    Color addedOverlayColor,
   }) {
     return RecommendationCompactCardStyle(
       titleTextStyle: titleTextStyle ?? this.titleTextStyle,
@@ -86,6 +89,7 @@ class RecommendationCompactCardStyle {
       overlayIconHeight: overlayIconHeight ?? this.overlayIconHeight,
       overlayIconWidth: overlayIconWidth ?? this.overlayIconWidth,
       overlayIcon: overlayIcon ?? this.overlayIcon,
+      addedOverlayColor: addedOverlayColor ?? this.addedOverlayColor,
     );
   }
 }
@@ -104,8 +108,10 @@ class _DefaultStyle extends RecommendationCompactCardStyle {
     color: Color(0xff767690),
     fontSize: 14,
   );
-  final RoundedButtonStatefulStyle leftActionButtonStyle = defaultRoundedButtonStyle;
-  final RoundedButtonStatefulStyle rightActionButtonStyle = defaultRoundedButtonStyle;
+  final RoundedButtonStatefulStyle leftActionButtonStyle =
+      defaultRoundedButtonStyle;
+  final RoundedButtonStatefulStyle rightActionButtonStyle =
+      defaultRoundedButtonStyle;
   final double imageHeight = 80;
   final BorderRadiusGeometry imageBorderRadius =
       const BorderRadius.all(Radius.circular(12.0));
@@ -114,6 +120,7 @@ class _DefaultStyle extends RecommendationCompactCardStyle {
   final EdgeInsets contentPadding = const EdgeInsets.all(32.0);
 
   final Color overlayColor = const Color(0x1924d900);
+  final Color addedOverlayColor = const Color(0x3325df0c);
   final double overlayIconHeight = 26;
   final double overlayIconWidth = 26;
 
@@ -148,6 +155,7 @@ class _DefaultStyle extends RecommendationCompactCardStyle {
       buttonShape: BoxShape.rectangle,
     ),
   );
+
   const _DefaultStyle(
       {TextStyle titleTextStyle,
       TextStyle subtitleTextStyle,
@@ -220,7 +228,8 @@ class RecommendationCompactCard extends StatelessWidget {
         overlayIcon: _style.overlayIcon,
         overlayIconHeight: _style.overlayIconHeight,
         overlayIconWidth: _style.overlayIconWidth,
-        overlayColor: _style.overlayColor,
+        overlayColor:
+            _viewModel.isAdded ? _style.addedOverlayColor : _style.overlayColor,
         showOverlayIcon: _viewModel.isAdded,
       ),
     );
@@ -302,7 +311,8 @@ class RecommendationCompactCard extends StatelessWidget {
           ),
           Expanded(
             child: Container(
-              decoration: _viewModel.isAdded ? _style.rightActionBoxDecoration : null,
+              decoration:
+                  _viewModel.isAdded ? _style.rightActionBoxDecoration : null,
               child: RoundedButtonStateful(
                 style: _style.rightActionButtonStyle,
                 viewModel: RoundedButtonStatefulViewModel(

--- a/lib/ui/recommendations/recommendation_compact_card/recommendation_compact_card_styles.dart
+++ b/lib/ui/recommendations/recommendation_compact_card/recommendation_compact_card_styles.dart
@@ -3,7 +3,6 @@ import 'package:flutter/widgets.dart';
 
 import 'recommendation_compact_card.dart';
 
-
 class RecommendationCompactCardStyles {
   static RecommendationCompactCardStyle build() =>
       _defaultRecommendationCardStyle;
@@ -40,6 +39,7 @@ class RecommendationCompactCardStyles {
       ),
       borderRadius: BorderRadius.circular(8),
     ),
+    addedOverlayColor: Color(0x3325df0c),
   );
 
   static RoundedButtonStatefulStyle _defaultLeftActionRoundedButtonStyle =

--- a/lib/ui/recommendations/recommendation_detail_card/recommendation_detail_card.dart
+++ b/lib/ui/recommendations/recommendation_detail_card/recommendation_detail_card.dart
@@ -32,6 +32,7 @@ class RecommendationDetailCardStyle {
   final double imageOverlayHeight;
   final double imageOverlayWidth;
   final String iconAssetOverlay;
+  final Color imageAddedOverlayColor;
 
   const RecommendationDetailCardStyle({
     this.titleTextStyle,
@@ -45,6 +46,7 @@ class RecommendationDetailCardStyle {
     this.imageOverlayHeight,
     this.imageOverlayWidth,
     this.iconAssetOverlay,
+    this.imageAddedOverlayColor,
   });
 
   RecommendationDetailCardStyle copyWith({
@@ -59,6 +61,7 @@ class RecommendationDetailCardStyle {
     double imageOverlayHeight,
     double imageOverlayWidth,
     String iconAssetOverlay,
+    Color imageAddedOverlayColor,
   }) {
     return RecommendationDetailCardStyle(
       titleTextStyle: titleTextStyle ?? this.titleTextStyle,
@@ -72,6 +75,8 @@ class RecommendationDetailCardStyle {
       imageOverlayHeight: imageOverlayHeight ?? this.imageOverlayHeight,
       imageOverlayWidth: imageOverlayHeight ?? this.imageOverlayHeight,
       iconAssetOverlay: iconAssetOverlay ?? this.iconAssetOverlay,
+      imageAddedOverlayColor:
+          imageAddedOverlayColor ?? this.imageAddedOverlayColor,
     );
   }
 }
@@ -130,6 +135,7 @@ class _DefaultStyle extends RecommendationDetailCardStyle {
   final BorderRadius imageRadius = const BorderRadius.all(Radius.circular(12));
   final double imageSize = 80;
   final Color imageOverlayColor = const Color(0x1924d900);
+  final Color imageAddedOverlayColor = const Color(0x3325df0c);
   final double imageOverlayHeight = 26;
   final double imageOverlayWidth = 26;
   final String iconAssetOverlay = 'assets/icons/tick_large.png';
@@ -145,6 +151,7 @@ class _DefaultStyle extends RecommendationDetailCardStyle {
     double imageOverlayHeight,
     double imageOverlayWidth,
     String iconAssetOverlay,
+    Color imageAddedOverlayColor,
   });
 }
 
@@ -252,7 +259,9 @@ class _RecommendationDetailCardState extends State<RecommendationDetailCard> {
           overlayIconWidth: widget._style.imageOverlayWidth,
           overlayIcon: widget._style.iconAssetOverlay,
           overlayIconHeight: widget._style.imageOverlayWidth,
-          overlayColor: widget._style.imageOverlayColor,
+          overlayColor: isAddedState
+              ? widget._style.imageAddedOverlayColor
+              : widget._style.imageOverlayColor,
         ),
       ),
     );

--- a/lib/ui/recommendations/recommendation_detail_card/recommendation_detail_card_styles.dart
+++ b/lib/ui/recommendations/recommendation_detail_card/recommendation_detail_card_styles.dart
@@ -10,29 +10,31 @@ class RecommendationDetailCardStyles {
 
   static RecommendationDetailCardStyle _defaultRecommendationDetailCardStyle =
       RecommendationDetailCardStyle(
-          titleTextStyle: TextStyle(
-            color: Color(0xff1a1b46),
-            fontSize: 27,
-            fontWeight: FontWeight.bold,
-          ),
-          subtitleTagStyle: _defaultDogTagStyle,
-          actionStyle: _defaultActionButtonStyle,
-          contentPadding: EdgeInsets.all(32.0),
-          imageSize: 80,
-          imageRadius: BorderRadius.all(
-            Radius.circular(12),
-          ),
-          imageOverlayWidth: 26,
-          imageOverlayHeight: 26,
-          imageOverlayColor: Color(0x1425df0c),
-          iconAssetOverlay: 'assets/icons/tick_large.png',
-          actionBoxDecoration: BoxDecoration(
-            border: Border.all(
-              width: 1,
-              color: Color(0xffe9eaf2),
-            ),
-            borderRadius: BorderRadius.circular(12),
-          ));
+    titleTextStyle: TextStyle(
+      color: Color(0xff1a1b46),
+      fontSize: 27,
+      fontWeight: FontWeight.bold,
+    ),
+    subtitleTagStyle: _defaultDogTagStyle,
+    actionStyle: _defaultActionButtonStyle,
+    contentPadding: EdgeInsets.all(32.0),
+    imageSize: 80,
+    imageRadius: BorderRadius.all(
+      Radius.circular(12),
+    ),
+    imageOverlayWidth: 26,
+    imageOverlayHeight: 26,
+    imageOverlayColor: Color(0x1425df0c),
+    iconAssetOverlay: 'assets/icons/tick_large.png',
+    actionBoxDecoration: BoxDecoration(
+      border: Border.all(
+        width: 1,
+        color: Color(0xffe9eaf2),
+      ),
+      borderRadius: BorderRadius.circular(12),
+    ),
+    imageAddedOverlayColor: Color(0x3325df0c),
+  );
 
   static RoundedButtonStatefulStyle _defaultActionButtonStyle =
       RoundedButtonStatefulStyle(


### PR DESCRIPTION
Fixes => https://amidodevelopment.atlassian.net/browse/FARM-454

#### 📲 What

Fix the image overlay color when selected

#### 🤔 Why
		
A green overlay should be displayed over the crop image when it has been selected (in addition to the green tick).
		
#### 🛠 How
		
More in-depth discussion of the change or implementation.

#### 👀 See
		
![20190807_120956](https://user-images.githubusercontent.com/23307893/62614819-6f537f80-b90c-11e9-991c-788b2f7af1a9.gif)

		 
#### ✅ Acceptance criteria

- [ ] Design Review for UI with BA completed. 
- [ ] Manually tested and verified on Android device/emulator (min. Lollipop 5.1)
- [ ] Showcase video / automation test
- [ ] Passing all tests
- [ ] Rebased/merged with latest changes from development and re-tested
- [ ] Removed unsed comments. TODOs must have JIRA for future work.

#### Coding Standards Checklist
- [ ] unit tests 80% coverage on testable code (functions, methods, class)
- [ ] (Architecture) redux state, reducers, actions, middleware defined under lib/redux
- [ ] ui elements defined under lib/ui. 
- [ ] Strings ready for localisation (e.g. defined in lib/utils/strings.dart)
- [ ] Assets (images/icons path) defined in lib/utils/assets.dart
- [ ] Colors defined in lib/utils/colors.dart
- [ ] Dimensions (ie margins padding) defined in lib/utils/dimens.dart
- [ ] TextStyles defined in lib/utils/styles.dart

Recommended Style Guide: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo

#### 🕵️‍♂️ How to test

Notes for QA

#### Reviewers

@farmsmart/amido @farmsmart/wamf