### PR TITLE
[FARM-449] Remove grey divider on crop screen

### DIFF
--- a/lib/ui/myplot/PlotDetail.dart
+++ b/lib/ui/myplot/PlotDetail.dart
@@ -104,6 +104,7 @@ class _PlotDetailState extends State<PlotDetail> {
         context: context,
         provider: viewModel.detailProvider,
       ),
+      needDivider: false,
     );
     final stages = Container(
         height: widget._style.stageSectionHeight,

--- a/lib/ui/myplot/PlotListItem.dart
+++ b/lib/ui/myplot/PlotListItem.dart
@@ -121,41 +121,55 @@ class _Constants {
 }
 
 class PlotListItem {
-  Widget buildListItem(
-      {PlotListItemViewModel viewModel,
-      Function onTap,
-      PlotListItemStyle itemStyle = const _DefaultStyle()}) {
+  Widget buildListItem({
+    PlotListItemViewModel viewModel,
+    Function onTap,
+    PlotListItemStyle itemStyle = const _DefaultStyle(),
+    bool needDivider = true,
+  }) {
     return GestureDetector(
-        onTap: onTap,
-        child: Card(
-            margin: itemStyle.cardEdgePadding,
-            elevation: itemStyle.elevation,
-            child: Column(children: <Widget>[
-              Container(
-                  padding: itemStyle.edgePadding,
-                  child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: <Widget>[
-                        _buildMainTextView(viewModel, itemStyle),
-                        SizedBox(width: itemStyle.imageLineSpace),
-                        Stack(
-                          alignment: AlignmentDirectional.center,
-                          children: <Widget>[
-                            _buildPlotImage(
-                                viewModel.imageProvider, itemStyle),
-                            CircularProgress(
-                              progress: viewModel.progress,
-                              lineWidth: itemStyle.circularLineWidth,
-                              size: itemStyle.circularSize,
-                            ),
-                          ],
-                        )
-                      ])),
-              Container(
-                  height: _Constants.dividerThickness,
-                  color: itemStyle.dividerColor,
-                  margin: itemStyle.dividerEdgePadding),
-            ])));
+      onTap: onTap,
+      child: Card(
+        margin: itemStyle.cardEdgePadding,
+        elevation: itemStyle.elevation,
+        child: Column(
+          children: <Widget>[
+            Container(
+              padding: itemStyle.edgePadding,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: <Widget>[
+                  _buildMainTextView(viewModel, itemStyle),
+                  SizedBox(width: itemStyle.imageLineSpace),
+                  Stack(
+                    alignment: AlignmentDirectional.center,
+                    children: <Widget>[
+                      _buildPlotImage(viewModel.imageProvider, itemStyle),
+                      CircularProgress(
+                        progress: viewModel.progress,
+                        lineWidth: itemStyle.circularLineWidth,
+                        size: itemStyle.circularSize,
+                      ),
+                    ],
+                  )
+                ],
+              ),
+            ),
+            _buildDivider(itemStyle, needDivider),
+          ],
+        ),
+      ),
+    );
+  }
+
+  _buildDivider(PlotListItemStyle itemStyle, bool needDivider) {
+    return !needDivider
+        ? SizedBox.shrink()
+        : Container(
+            height: _Constants.dividerThickness,
+            color: itemStyle.dividerColor,
+            margin: itemStyle.dividerEdgePadding,
+          );
   }
 
   _buildMainTextView(


### PR DESCRIPTION
Fixes => https://amidodevelopment.atlassian.net/browse/FARM-449

#### 📲 What

Removed the grey line on crop screen (My plot)

#### 🤔 Why
		
The crop screen displays a grey line above the crop stage slider (see bug image below). This should be removed as per designs.
		
#### 🛠 How
		
Added a param needDivider with value 'true' as default and set the value to false when is building for crop screen on my plot

#### 👀 See

<img src="https://user-images.githubusercontent.com/23307893/62616424-bee77a80-b90f-11e9-8253-f058f8ad20e5.jpg" width=50% />


#### ✅ Acceptance criteria

- [ ] Design Review for UI with BA completed. 
- [ ] Manually tested and verified on Android device/emulator (min. Lollipop 5.1)
- [ ] Showcase video / automation test
- [ ] Passing all tests
- [ ] Rebased/merged with latest changes from development and re-tested
- [ ] Removed unsed comments. TODOs must have JIRA for future work.

#### Coding Standards Checklist
- [ ] unit tests 80% coverage on testable code (functions, methods, class)
- [ ] (Architecture) redux state, reducers, actions, middleware defined under lib/redux
- [ ] ui elements defined under lib/ui. 
- [ ] Strings ready for localisation (e.g. defined in lib/utils/strings.dart)
- [ ] Assets (images/icons path) defined in lib/utils/assets.dart
- [ ] Colors defined in lib/utils/colors.dart
- [ ] Dimensions (ie margins padding) defined in lib/utils/dimens.dart
- [ ] TextStyles defined in lib/utils/styles.dart

Recommended Style Guide: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo

#### 🕵️‍♂️ How to test

Notes for QA

#### Reviewers

@farmsmart/amido @farmsmart/wamf