### PR TITLE
Idea to kill off messy playground datasources.

### DIFF
--- a/lib/ui/playground/data/AtomicPlayground.dart
+++ b/lib/ui/playground/data/AtomicPlayground.dart
@@ -1,0 +1,75 @@
+import 'package:farmsmart_flutter/ui/playground/data/playground_data_source.dart';
+import 'package:farmsmart_flutter/ui/playground/playground_view.dart';
+import 'package:farmsmart_flutter/ui/playground/playground_widget.dart';
+import 'package:flutter/widgets.dart';
+
+enum AtomicType { atom, molecule, organism, template, page }
+
+class _Strings {
+  static const atomTitle = "Atom";
+  static const moleculeTitle = "Molecule";
+  static const organismTitle = "Organism";
+  static const templateTitle = "Template";
+  static const pageTitle = "Page";
+}
+
+class AtomicPlaygroundComponent {
+  static List<AtomicPlaygroundComponent> _components = [];
+  final AtomicType type;
+  final String title;
+  final Widget component;
+
+  AtomicPlaygroundComponent({@required AtomicType type, @required String title, @required Widget component})
+      : this.title = title,
+        this.type = type,
+        this.component = component {
+    _components.add(this);
+  }
+
+  Widget asPlaygroundEntry() {
+    return PlaygroundWidget(
+      child: component,
+      title: title,
+    );
+  }
+
+  static List<AtomicPlaygroundComponent> _getComponents() {
+    return _components;
+  }
+}
+
+class AtomicPlaygroundDatasource implements PlaygroundDataSource {
+  @override
+  List<Widget> getList() {
+    return [
+      PlaygroundWidget(
+        title: _Strings.atomTitle,
+        child: PlaygroundView(widgetList: _generateFor(AtomicType.atom)),
+      ),
+      PlaygroundWidget(
+        title: _Strings.moleculeTitle,
+        child: PlaygroundView(widgetList: _generateFor(AtomicType.molecule)),
+      ),
+      PlaygroundWidget(
+        title: _Strings.organismTitle,
+        child: PlaygroundView(widgetList: _generateFor(AtomicType.organism)),
+      ),
+      PlaygroundWidget(
+        title: _Strings.templateTitle,
+        child: PlaygroundView(widgetList: _generateFor(AtomicType.template)),
+      ),
+      PlaygroundWidget(
+        title: _Strings.pageTitle,
+        child: PlaygroundView(widgetList: _generateFor(AtomicType.page)),
+      ),
+    ];
+  }
+
+  List<Widget> _generateFor(AtomicType type) {
+    return AtomicPlaygroundComponent._getComponents().where((component) {
+      return component.type == type;
+    }).map((component) {
+      return component.asPlaygroundEntry();
+    }).toList();
+  }
+}

--- a/lib/ui/playground/data/playground_datasource_impl.dart
+++ b/lib/ui/playground/data/playground_datasource_impl.dart
@@ -1,3 +1,4 @@
+import 'package:farmsmart_flutter/ui/playground/data/AtomicPlayground.dart';
 import 'package:farmsmart_flutter/ui/playground/data/playground_tasks_datasource.dart';
 import 'package:farmsmart_flutter/ui/playground/data/playground_atom_datasource.dart';
 import 'package:farmsmart_flutter/ui/playground/playground_view.dart';
@@ -12,6 +13,12 @@ class PlaygroundDataSourceImpl implements PlaygroundDataSource {
             title: 'Atoms',
             child: PlaygroundView(
               widgetList: PlayGroundAtomDataSource().getList(),
+            ),
+          ),
+          PlaygroundWidget(
+            title: 'Atomic playground',
+            child: PlaygroundView(
+              widgetList: AtomicPlaygroundDatasource().getList(),
             ),
           ),
         ] +


### PR DESCRIPTION
This is a PR to discuss a way to solve the issue of conflicting large playground datasources.


My idea was to use reflection and just generate a datasource that would crate a list from all subclasses of a base class. This way we can add the playground widget entry in any file and not have to manually add to a list. 
HOWEVER. dart mirror´s  are not implemented in flutter!

This PR has a system that "kind of works", but you have to create an instance of the Component somewhere for it to show up in the datasource.
 
So I wonder if there is a way to do this using code generation instead?

I have made a start and defined a playground datasource that has the Atomic design categories.

Please PR ideas to this branch.