### PR TITLE
[FARM-477] Reset navigation when tap a tab

### DIFF
--- a/lib/ui/bottombar/persistent_bottom_navigation_bar.dart
+++ b/lib/ui/bottombar/persistent_bottom_navigation_bar.dart
@@ -41,7 +41,12 @@ class _PersistentBottomNavigationBarState
       elevation: 0,
       backgroundColor: widget.backgroundColor,
       type: BottomNavigationBarType.fixed,
-      onTap: (int index) => setState(() => _selectedIndex = index),
+      onTap: (int index) {
+        if(_selectedIndex == index){
+          widget.tabs[_selectedIndex].navigatorKey.currentState.popUntil((route) => route.isFirst);
+        }
+        setState(() => _selectedIndex = index);
+      },
       currentIndex: selectedIndex,
       items: _buildBarItems(widget.tabs),
     );


### PR DESCRIPTION
Fixes => https://amidodevelopment.atlassian.net/browse/FARM-477

#### 📲 What

Reset navigation stack when pressing a tab on the bottom bar. 

#### 🤔 Why
		
We want to clear all the back stack to go to the first route of the tab
		
#### 🛠 How
		
Added the `popUntil((route) => route.isFirst);`

#### 👀 See
		
![ezgif com-resize](https://user-images.githubusercontent.com/23307893/62711953-3265b680-b9fa-11e9-9ccd-5d7c693b1801.gif)
		 
#### ✅ Acceptance criteria

- [ ] Design Review for UI with BA completed. 
- [ ] Manually tested and verified on Android device/emulator (min. Lollipop 5.1)
- [ ] Showcase video / automation test
- [ ] Passing all tests
- [ ] Rebased/merged with latest changes from development and re-tested
- [ ] Removed unsed comments. TODOs must have JIRA for future work.

#### Coding Standards Checklist
- [ ] unit tests 80% coverage on testable code (functions, methods, class)
- [ ] (Architecture) redux state, reducers, actions, middleware defined under lib/redux
- [ ] ui elements defined under lib/ui. 
- [ ] Strings ready for localisation (e.g. defined in lib/utils/strings.dart)
- [ ] Assets (images/icons path) defined in lib/utils/assets.dart
- [ ] Colors defined in lib/utils/colors.dart
- [ ] Dimensions (ie margins padding) defined in lib/utils/dimens.dart
- [ ] TextStyles defined in lib/utils/styles.dart

Recommended Style Guide: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo

#### 🕵️‍♂️ How to test

Notes for QA

#### Reviewers

@farmsmart/amido @farmsmart/wamf
