### PR TITLE
[bugfix/FARM-486] Fix remove crop dialog labels

### DIFF
--- a/lib/ui/myplot/PlotDetail.dart
+++ b/lib/ui/myplot/PlotDetail.dart
@@ -32,10 +32,12 @@ class _LocalisedStrings {
 
   static confirm() => Intl.message('Confirm');
 
+  static remove() => Intl.message('Remove');
+
   static removeDialogTitle() => Intl.message('Remove crop');
 
   static removeDialogDescription() =>
-      Intl.message('Are you sure you want delete the crop?');
+      Intl.message('Are you sure you want to remove the crop? All progress will be lost.');
 
   static viewMore() => Intl.message('Learn more about');
 }
@@ -196,7 +198,7 @@ class _PlotDetailState extends State<PlotDetail> {
       Alert(
         viewModel: AlertViewModel(
           cancelActionText: _LocalisedStrings.cancelAction(),
-          confirmActionText: _LocalisedStrings.confirm(),
+          confirmActionText: _LocalisedStrings.remove(),
           titleText: _LocalisedStrings.removeDialogTitle(),
           detailText: _LocalisedStrings.removeDialogDescription(),
           confirmAction: () {


### PR DESCRIPTION
https://amidodevelopment.atlassian.net/browse/FARM-486

#### 📲 What

Change ‘delete’ to remove (this applies to popup widget and dialogue.
Dialogue header: Remove crop
Text: Are you sure you want to remove the crop? All progress will be lost.
Buttons: Cancel, Remove

#### 🤔 Why
		
Needed as per design
		
#### 🛠 How
		
Replaced labels

#### 👀 See
		
<img src="https://user-images.githubusercontent.com/23307893/64543671-ea51f080-d325-11e9-9ff8-442f0dc08f1a.jpg" width=50% />

		 
#### ✅ Acceptance criteria

- [ ] Design Review for UI with BA completed. 
- [ ] Manually tested and verified on Android device/emulator (min. Lollipop 5.1)
- [ ] Showcase video / automation test
- [ ] Passing all tests
- [ ] Rebased/merged with latest changes from development and re-tested
- [ ] Removed unsed comments. TODOs must have JIRA for future work.

#### Coding Standards Checklist
- [ ] unit tests 80% coverage on testable code (functions, methods, class)
- [ ] (Architecture) redux state, reducers, actions, middleware defined under lib/redux
- [ ] ui elements defined under lib/ui. 
- [ ] Strings ready for localisation (e.g. defined in lib/utils/strings.dart)
- [ ] Assets (images/icons path) defined in lib/utils/assets.dart
- [ ] Colors defined in lib/utils/colors.dart
- [ ] Dimensions (ie margins padding) defined in lib/utils/dimens.dart
- [ ] TextStyles defined in lib/utils/styles.dart

Recommended Style Guide: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo

#### 🕵️‍♂️ How to test

Notes for QA

#### Reviewers

@farmsmart/amido @farmsmart/wamf