### PR TITLE
[bugfix/FARM-472] Reduce space between image and content on Article screen

### DIFF
--- a/lib/ui/article/ArticleDetail.dart
+++ b/lib/ui/article/ArticleDetail.dart
@@ -46,16 +46,17 @@ abstract class ArticleDetailStyle {
   final int maxLinesPerTitle;
 
   ArticleDetailStyle(
-      this.titlePageStyle,
-      this.dateStyle,
-      this.bodyStyle,
-      this.titlePagePadding,
-      this.leftRightPadding,
-      this.bodyPadding,
-      this.spaceBetweenDataAndImage,
-      this.spaceBetweenElements,
-      this.imageHeight,
-      this.maxLinesPerTitle);
+    this.titlePageStyle,
+    this.dateStyle,
+    this.bodyStyle,
+    this.titlePagePadding,
+    this.leftRightPadding,
+    this.bodyPadding,
+    this.spaceBetweenDataAndImage,
+    this.spaceBetweenElements,
+    this.imageHeight,
+    this.maxLinesPerTitle,
+  );
 }
 
 class _DefaultStyle implements ArticleDetailStyle {
@@ -76,7 +77,7 @@ class _DefaultStyle implements ArticleDetailStyle {
       const EdgeInsets.only(left: 32.0, right: 32.0);
   final EdgeInsets bodyPadding = const EdgeInsets.only(left: 32.0, right: 32.0);
 
-  final double spaceBetweenDataAndImage = 36;
+  final double spaceBetweenDataAndImage = 25;
   final double spaceBetweenElements = 41;
   final double imageHeight = 192;
 
@@ -250,7 +251,6 @@ class ArticleDetail extends StatelessWidget implements ListViewSection {
         ? [
             SizedBox(height: _style.spaceBetweenElements),
             image,
-            SizedBox(height: _style.spaceBetweenElements)
           ]
         : [];
     final List<Widget> bodySection = body != null
@@ -309,7 +309,7 @@ class ArticleDetail extends StatelessWidget implements ListViewSection {
   }
 
   Widget _buildImage() {
-    if(!_articleImageVisible){
+    if (!_articleImageVisible) {
       return null;
     }
     if (_viewModel.image == null) {


### PR DESCRIPTION
[FARM-472]

#### 📲 What

Reduced the space between image and content on Article screen

#### 🤔 Why
		
It has so much space
		
#### 👀 See

<img src="https://user-images.githubusercontent.com/23307893/64607110-1f168400-d3c8-11e9-98d2-8a8801a1c4ff.jpg" width=50% />

		 
#### ✅ Acceptance criteria

- [ ] Design Review for UI with BA completed. 
- [ ] Manually tested and verified on Android device/emulator (min. Lollipop 5.1)
- [ ] Showcase video / automation test
- [ ] Passing all tests
- [ ] Rebased/merged with latest changes from development and re-tested
- [ ] Removed unsed comments. TODOs must have JIRA for future work.

#### Coding Standards Checklist
- [ ] unit tests 80% coverage on testable code (functions, methods, class)
- [ ] (Architecture) redux state, reducers, actions, middleware defined under lib/redux
- [ ] ui elements defined under lib/ui. 
- [ ] Strings ready for localisation (e.g. defined in lib/utils/strings.dart)
- [ ] Assets (images/icons path) defined in lib/utils/assets.dart
- [ ] Colors defined in lib/utils/colors.dart
- [ ] Dimensions (ie margins padding) defined in lib/utils/dimens.dart
- [ ] TextStyles defined in lib/utils/styles.dart

Recommended Style Guide: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo

#### 🕵️‍♂️ How to test

Notes for QA

#### Reviewers

@farmsmart/amido @farmsmart/wamf
