### PR TITLE
[bugfix/FARM-508] Fix input alert to start with the current value and auto focus ON

### DIFF
--- a/lib/ui/common/InputAlert.dart
+++ b/lib/ui/common/InputAlert.dart
@@ -19,6 +19,7 @@ class _Constants {
 }
 
 class InputAlertViewModel {
+  String initialValue;
   String cancelActionText;
   String confirmActionText;
   String titleText;
@@ -29,6 +30,7 @@ class InputAlertViewModel {
     @required this.cancelActionText,
     @required this.confirmActionText,
     @required this.titleText,
+    this.initialValue,
     this.hint,
     this.confirmInputAction,
   });
@@ -104,11 +106,9 @@ class _DefaultStyle extends InputAlertStyle {
 
 const InputAlertStyle _defaultStyle = const _DefaultStyle();
 
-class InputAlert extends StatelessWidget {
+class InputAlert extends StatefulWidget {
   final InputAlertViewModel _viewModel;
   final InputAlertStyle _style;
-
-  TextEditingController _textFieldController = TextEditingController();
 
   static present(InputAlert alert, BuildContext context) {
     return showDialog<bool>(
@@ -127,6 +127,21 @@ class InputAlert extends StatelessWidget {
         super(key: key);
 
   @override
+  _InputAlertState createState() => _InputAlertState();
+}
+
+class _InputAlertState extends State<InputAlert> {
+  TextEditingController _textFieldController = TextEditingController();
+  final _focusNode = FocusNode();
+
+  @override
+  void initState() {
+    _textFieldController.text = widget._viewModel.initialValue;
+    _selectAllOnFocusListener();
+    super.initState();
+  }
+  
+  @override
   Widget build(BuildContext context) {
     return Material(
       type: MaterialType.transparency,
@@ -138,7 +153,7 @@ class InputAlert extends StatelessWidget {
             margin: _Constants.alertEdgePadding,
             decoration: BoxDecoration(
               borderRadius: _Constants.cornerRadius,
-              color: _style.backgroundColor,
+              color: widget._style.backgroundColor,
             ),
             child: Padding(
               padding: _Constants.alertInnerPadding,
@@ -147,8 +162,8 @@ class InputAlert extends StatelessWidget {
                 mainAxisSize: MainAxisSize.min,
                 children: <Widget>[
                   Text(
-                    _viewModel.titleText,
-                    style: _style.titleTextStyle,
+                    widget._viewModel.titleText,
+                    style: widget._style.titleTextStyle,
                   ),
                   SizedBox(
                     height: _Constants.titleLineSpace,
@@ -158,7 +173,10 @@ class InputAlert extends StatelessWidget {
                     children: <Widget>[
                       TextField(
                         controller: _textFieldController,
-                        decoration: InputDecoration(hintText: _viewModel.hint),
+                        decoration:
+                            InputDecoration(hintText: widget._viewModel.hint),
+                        autofocus: true,
+                        focusNode: _focusNode,
                       ),
                       SizedBox(
                         height: _Constants.detailLineSpace,
@@ -182,7 +200,7 @@ class InputAlert extends StatelessWidget {
       Expanded(
         child: RoundedButton(
           viewModel: RoundedButtonViewModel(
-            title: _viewModel.cancelActionText,
+            title: widget._viewModel.cancelActionText,
             onTap: () => Navigator.of(context).pop(),
           ),
           style: RoundedButtonStyle.actionSheetLargeRoundedButton().copyWith(
@@ -198,14 +216,14 @@ class InputAlert extends StatelessWidget {
       Expanded(
         child: RoundedButton(
           viewModel: RoundedButtonViewModel(
-              title: _viewModel.confirmActionText,
+              title: widget._viewModel.confirmActionText,
               onTap: () => confirmAndDismiss(context)),
           style: RoundedButtonStyle.actionSheetLargeRoundedButton().copyWith(
             edgePadding: EdgeInsets.symmetric(horizontal: 8),
             height: _Constants.actionHeight,
             width: _Constants.actionWidth,
-            backgroundColor: _style.actionBackgroundColor,
-            buttonTextStyle: _style.actionTextStyle,
+            backgroundColor: widget._style.actionBackgroundColor,
+            buttonTextStyle: widget._style.actionTextStyle,
             borderRadius: _Constants.actionCornerRadius,
           ),
         ),
@@ -216,8 +234,17 @@ class InputAlert extends StatelessWidget {
   confirmAndDismiss(BuildContext context) {
     if (_textFieldController.text != null &&
         _textFieldController.text.isNotEmpty) {
-      _viewModel.confirmInputAction(_textFieldController.text);
+      widget._viewModel.confirmInputAction(_textFieldController.text);
       Navigator.of(context).pop();
     }
+  }
+
+  void _selectAllOnFocusListener() {
+    _focusNode.addListener(() {
+      _textFieldController.selection = TextSelection(
+        baseOffset: 0,
+        extentOffset: _textFieldController.text.length,
+      );
+    });
   }
 }

--- a/lib/ui/common/InputAlert.dart
+++ b/lib/ui/common/InputAlert.dart
@@ -16,6 +16,7 @@ class _Constants {
   static final BorderRadius actionCornerRadius =
       const BorderRadius.all(Radius.circular(14));
   static final double actionLineSpace = 8;
+  static final int baseInputTextOffset = 0;
 }
 
 class InputAlertViewModel {
@@ -242,7 +243,7 @@ class _InputAlertState extends State<InputAlert> {
   void _selectAllOnFocusListener() {
     _focusNode.addListener(() {
       _textFieldController.selection = TextSelection(
-        baseOffset: 0,
+        baseOffset: _Constants.baseInputTextOffset,
         extentOffset: _textFieldController.text.length,
       );
     });

--- a/lib/ui/myplot/PlotDetail.dart
+++ b/lib/ui/myplot/PlotDetail.dart
@@ -245,6 +245,7 @@ class _PlotDetailState extends State<PlotDetail> {
   InputAlert _renameInputAlert(PlotDetailViewModel viewModel) {
     return InputAlert(
       viewModel: InputAlertViewModel(
+          initialValue: viewModel.title,
           cancelActionText: _LocalisedStrings.cancelAction(),
           confirmActionText: _LocalisedStrings.confirm(),
           titleText: _LocalisedStrings.renameAction(),

--- a/lib/ui/profile/Profile.dart
+++ b/lib/ui/profile/Profile.dart
@@ -637,6 +637,7 @@ class Profile extends StatelessWidget {
   InputAlert _renameInputAlert(ProfileViewModel viewModel) {
     return InputAlert(
       viewModel: InputAlertViewModel(
+          initialValue: viewModel.username,
           cancelActionText: _LocalisedStrings.cancel(),
           confirmActionText: _LocalisedStrings.confirm(),
           titleText: _LocalisedStrings.renameProfile(),


### PR DESCRIPTION
[FARM-508]

#### 📲 What

Fix input alert to start with the current value and auto focus ON

#### 🤔 Why
		
Better UX

#### 👀 See

![ezgif com-video-to-gif-14](https://user-images.githubusercontent.com/23307893/64795808-fa184180-d57e-11e9-99ba-c8da84fe2ce1.gif)

		 
#### ✅ Acceptance criteria

- [ ] Design Review for UI with BA completed. 
- [ ] Manually tested and verified on Android device/emulator (min. Lollipop 5.1)
- [ ] Showcase video / automation test
- [ ] Passing all tests
- [ ] Rebased/merged with latest changes from development and re-tested
- [ ] Removed unsed comments. TODOs must have JIRA for future work.

#### Coding Standards Checklist
- [ ] unit tests 80% coverage on testable code (functions, methods, class)
- [ ] (Architecture) redux state, reducers, actions, middleware defined under lib/redux
- [ ] ui elements defined under lib/ui. 
- [ ] Strings ready for localisation (e.g. defined in lib/utils/strings.dart)
- [ ] Assets (images/icons path) defined in lib/utils/assets.dart
- [ ] Colors defined in lib/utils/colors.dart
- [ ] Dimensions (ie margins padding) defined in lib/utils/dimens.dart
- [ ] TextStyles defined in lib/utils/styles.dart

Recommended Style Guide: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo

#### 🕵️‍♂️ How to test

Notes for QA

#### Reviewers

@farmsmart/amido @farmsmart/wamf
