### PR TITLE
[FARM-514] Cannot open chat again after back button pressed (Android)

### DIFF
--- a/lib/chat/ChatPage.dart
+++ b/lib/chat/ChatPage.dart
@@ -69,9 +69,14 @@ class _ChatPageState extends State<ChatPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: _buildSimpleAppBar(context),
-      body: _buildChat(context),
+    return WillPopScope(
+      onWillPop: () {
+        _cancel(context);
+      },
+      child: Scaffold(
+        appBar: _buildSimpleAppBar(context),
+        body: _buildChat(context),
+      ),
     );
   }
 


### PR DESCRIPTION
[FARM-514]

#### 📲 What

Catch Back button pressed on Android to set the state of the chat to cancel

#### 🤔 Why
		
Bug on Android
		
#### 🛠 How
		
Added WillPopScope

#### 👀 See
		
![ezgif com-video-to-gif-18](https://user-images.githubusercontent.com/23307893/65257843-2e9d7780-db02-11e9-96bf-4aa65a95d6cb.gif)

		 
#### ✅ Acceptance criteria

- [ ] Design Review for UI with BA completed. 
- [ ] Manually tested and verified on Android device/emulator (min. Lollipop 5.1)
- [ ] Showcase video / automation test
- [ ] Passing all tests
- [ ] Rebased/merged with latest changes from development and re-tested
- [ ] Removed unsed comments. TODOs must have JIRA for future work.

#### Coding Standards Checklist
- [ ] unit tests 80% coverage on testable code (functions, methods, class)
- [ ] (Architecture) redux state, reducers, actions, middleware defined under lib/redux
- [ ] ui elements defined under lib/ui. 
- [ ] Strings ready for localisation (e.g. defined in lib/utils/strings.dart)
- [ ] Assets (images/icons path) defined in lib/utils/assets.dart
- [ ] Colors defined in lib/utils/colors.dart
- [ ] Dimensions (ie margins padding) defined in lib/utils/dimens.dart
- [ ] TextStyles defined in lib/utils/styles.dart

Recommended Style Guide: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo

#### 🕵️‍♂️ How to test

Notes for QA

#### Reviewers

@farmsmart/amido @farmsmart/wamf