### PR TITLE
ViewModelProvider dependency injection using the dart provider lib.

### DIFF
--- a/lib/model/bloc/SequencedViewModelProvider.dart
+++ b/lib/model/bloc/SequencedViewModelProvider.dart
@@ -4,7 +4,7 @@ import 'dart:async';
 
 import 'package:farmsmart_flutter/model/bloc/ViewModelProvider.dart';
 
-class SequencedViewModelProvider<T> implements ViewModelProvider<T> {
+class SequencedViewModelProvider<T> implements ViewModelProviderInterface<T> {
 
   final Duration _tempo;
   final List<T> _sequence;

--- a/lib/model/bloc/StaticViewModelProvider.dart
+++ b/lib/model/bloc/StaticViewModelProvider.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:farmsmart_flutter/model/bloc/ViewModelProvider.dart';
 
-class StaticViewModelProvider<T> implements ViewModelProvider<T> {
+class StaticViewModelProvider<T> implements ViewModelProviderInterface<T> {
 
   final T _viewModel;
   final StreamController _controller = StreamController<T>.broadcast();

--- a/lib/model/bloc/ViewModelProvider.dart
+++ b/lib/model/bloc/ViewModelProvider.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-abstract class ViewModelProvider<T> {
+abstract class ViewModelProviderInterface<T> {
 
   Stream<T> stream();
   T initial();

--- a/lib/model/bloc/article/ArticleListProvider.dart
+++ b/lib/model/bloc/article/ArticleListProvider.dart
@@ -14,7 +14,7 @@ import 'package:farmsmart_flutter/ui/article/viewModel/ArticleListViewModel.dart
    [repo , model] -> [ViewModelProvider, Transformer] -> [viewModel, widget]
 */
 
-class ArticleListProvider implements ViewModelProvider<ArticleListViewModel> {
+class ArticleListProvider implements ViewModelProviderInterface<ArticleListViewModel> {
   final ArticleRepositoryInterface _repo;
   final ArticleCollectionGroup _group;
   final String _title;

--- a/lib/model/bloc/home/HomeViewModelProvider.dart
+++ b/lib/model/bloc/home/HomeViewModelProvider.dart
@@ -25,7 +25,7 @@ class HomeViewModel implements LoadableViewModel, RefreshableViewModel {
   );
 }
 
-class HomeViewModelProvider implements ViewModelProvider<HomeViewModel> {
+class HomeViewModelProvider implements ViewModelProviderInterface<HomeViewModel> {
   final AccountRepositoryInterface _accountRepository;
   final StreamController<HomeViewModel> _controller =
       StreamController<HomeViewModel>.broadcast();

--- a/lib/model/bloc/plot/PlotDetailProvider.dart
+++ b/lib/model/bloc/plot/PlotDetailProvider.dart
@@ -10,7 +10,7 @@ import 'PlotToPlotDetailViewModel.dart';
 import 'StageBusinessLogic.dart';
 import 'StageToStageCardViewModel.dart';
 
-class PlotDetailProvider implements ViewModelProvider<PlotDetailViewModel> {
+class PlotDetailProvider implements ViewModelProviderInterface<PlotDetailViewModel> {
   PlotDetailViewModel _snapshot;
 
   PlotEntity _plot;

--- a/lib/model/bloc/plot/PlotListProvider.dart
+++ b/lib/model/bloc/plot/PlotListProvider.dart
@@ -23,7 +23,7 @@ class _LocalisedStrings {
   static String addCrop() => Intl.message('Add Another Crop');
 }
 
-class PlotListProvider implements ViewModelProvider<PlotListViewModel> {
+class PlotListProvider implements ViewModelProviderInterface<PlotListViewModel> {
   final PlotRepositoryInterface _plotRepo;
   final RecommendationListProvider _recommendationsProvider;
   final String _title;

--- a/lib/model/bloc/profile/ProfileDetailProvider.dart
+++ b/lib/model/bloc/profile/ProfileDetailProvider.dart
@@ -22,7 +22,7 @@ import '../ViewModelProvider.dart';
 
 class ProfileDetailProvider
     extends ObjectTransformer<ProfileEntity, ProfileViewModel>
-    implements ViewModelProvider<ProfileViewModel> {
+    implements ViewModelProviderInterface<ProfileViewModel> {
   final AccountRepositoryInterface _accountRepository;
   final PlotRepositoryInterface _plotRepository;
   ProfileRepositoryInterface _profileRepository;

--- a/lib/model/bloc/profile/SwitchProfileListProvider.dart
+++ b/lib/model/bloc/profile/SwitchProfileListProvider.dart
@@ -15,7 +15,7 @@ class _LocalisedStrings {
 }
 
 class SwitchProfileListProvider
-    implements ViewModelProvider<SwitchProfileListViewModel> {
+    implements ViewModelProviderInterface<SwitchProfileListViewModel> {
   final AccountRepositoryInterface _accountRepository;
   SwitchProfileListViewModel _snapshot;
   final StreamController<SwitchProfileListViewModel> _controller =

--- a/lib/model/bloc/recommendations/RecommendationListProvider.dart
+++ b/lib/model/bloc/recommendations/RecommendationListProvider.dart
@@ -23,7 +23,7 @@ class _Constants {
 }
 
 class RecommendationListProvider
-    implements ViewModelProvider<RecommendationsListViewModel> {
+    implements ViewModelProviderInterface<RecommendationsListViewModel> {
   final String _title;
   final double _heroThreshold;
   final CropRepositoryInterface _cropRepo;
@@ -153,7 +153,7 @@ class RecommendationListProvider
     _update(controller);
   }
 
-  ViewModelProvider<CropDetailViewModel> _detailProvider(CropEntity crop) {
+  ViewModelProviderInterface<CropDetailViewModel> _detailProvider(CropEntity crop) {
     final transformer = CropDetailTransformer();
     final cropViewModel = transformer.transform(from: crop);
     final provider =

--- a/lib/model/bloc/startup/StartupViewModelProvider.dart
+++ b/lib/model/bloc/startup/StartupViewModelProvider.dart
@@ -28,7 +28,7 @@ class _Assets {
   static const logoImage = "assets/raw/logo_default.png";
 }
 
-class StartupViewModelProvider implements ViewModelProvider<StartupViewModel> {
+class StartupViewModelProvider implements ViewModelProviderInterface<StartupViewModel> {
   final AccountRepositoryInterface _accountRepository;
   StartupViewModel _snapshot;
   final StreamController<StartupViewModel> _controller =

--- a/lib/model/bloc/transactions/ProfitLossListProvider.dart
+++ b/lib/model/bloc/transactions/ProfitLossListProvider.dart
@@ -17,7 +17,7 @@ class _LocalisedStrings {
 }
 
 class ProfitLossListProvider
-    implements ViewModelProvider<ProfitLossListViewModel> {
+    implements ViewModelProviderInterface<ProfitLossListViewModel> {
   final TransactionRepositoryInterface _transactionsRepository;
   final PlotRepositoryInterface _plotRepository;
   ProfitLossListViewModel _snapshot;

--- a/lib/ui/article/ArticleList.dart
+++ b/lib/ui/article/ArticleList.dart
@@ -58,12 +58,12 @@ const ArticleListStyle _defaultStyle = const _DefaultStyle();
 
 class ArticleList extends StatelessWidget {
   static ArticleListStyle defaultStyle = _defaultStyle;
-  final ViewModelProvider<ArticleListViewModel> _viewModelProvider;
+  final ViewModelProviderInterface<ArticleListViewModel> _viewModelProvider;
   final ArticleListStyle _style;
 
   ArticleList(
       {Key key,
-      ViewModelProvider<ArticleListViewModel> viewModelProvider,
+      ViewModelProviderInterface<ArticleListViewModel> viewModelProvider,
       ArticleListStyle style = _defaultStyle})
       : this._style = style,
         this._viewModelProvider = viewModelProvider,
@@ -72,7 +72,7 @@ class ArticleList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ViewModelProviderBuilder<ArticleListViewModel>(
-      provider: _viewModelProvider,
+      defaultProvider: _viewModelProvider,
       successBuilder: _buildSuccess,
     );
   }

--- a/lib/ui/common/ProfileAvatar.dart
+++ b/lib/ui/common/ProfileAvatar.dart
@@ -11,7 +11,7 @@ class _Constants {
 }
 
 class ProfileAvatar extends StatelessWidget {
-  final ViewModelProvider<ProfileViewModel> _viewModelProvider;
+  final ViewModelProviderInterface<ProfileViewModel> _viewModelProvider;
   final double _width;
   final double _height;
   final Color _backgroundColor;
@@ -19,7 +19,7 @@ class ProfileAvatar extends StatelessWidget {
 
   const ProfileAvatar({
     Key key,
-    ViewModelProvider<ProfileViewModel> viewModelProvider,
+    ViewModelProviderInterface<ProfileViewModel> viewModelProvider,
     double width,
     double height,
     TextStyle textStyle,
@@ -34,7 +34,7 @@ class ProfileAvatar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ViewModelProviderBuilder(
-      provider: _viewModelProvider,
+      defaultProvider: _viewModelProvider,
       successBuilder: _successBuilder,
     );
   }

--- a/lib/ui/common/ViewModelProviderBuilder.dart
+++ b/lib/ui/common/ViewModelProviderBuilder.dart
@@ -6,6 +6,7 @@ import 'package:farmsmart_flutter/ui/common/RefreshableViewModel.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
 import 'LoadableViewModel.dart';
 
 class _LocalisedStrings {
@@ -18,18 +19,18 @@ typedef WidgetBuilder<T> = Widget Function(
     {BuildContext context, AsyncSnapshot<T> snapshot});
 
 class ViewModelProviderBuilder<T> extends StatelessWidget {
-  final ViewModelProvider<T> _provider;
+  final ViewModelProviderInterface<T> _defaultProvider;
   final WidgetBuilder<T> _successBuilder;
   final WidgetBuilder<T> _errorBuilder;
   final WidgetBuilder<T> _loadingBuilder;
 
   const ViewModelProviderBuilder(
       {Key key,
-      ViewModelProvider<T> provider,
+      ViewModelProviderInterface<T> defaultProvider,
       WidgetBuilder<T> successBuilder,
       WidgetBuilder<T> errorBuilder,
       WidgetBuilder<T> loadingBuilder})
-      : this._provider = provider,
+      : this._defaultProvider = defaultProvider,
         this._successBuilder = successBuilder,
         this._errorBuilder = errorBuilder,
         this._loadingBuilder = loadingBuilder,
@@ -39,10 +40,11 @@ class ViewModelProviderBuilder<T> extends StatelessWidget {
   Widget build(BuildContext context) {
     final errorBuilder = _errorBuilder ?? _defaultErrorBuilder;
     final loadingBuilder = _loadingBuilder ?? _defaultLoadingBuilder;
-
+    final provider = _defaultProvider ?? Provider.of<ViewModelProviderInterface<T>>(context, listen: false,);
+    assert(provider != null, "Missing dependency. No default or injected dependency provider can be found! ",);
     return StreamBuilder<T>(
-        stream: _provider.stream(),
-        initialData: _provider.initial(),
+        stream: provider.stream(),
+        initialData: provider.initial(),
         builder: (
           BuildContext context,
           AsyncSnapshot<T> snapshot,

--- a/lib/ui/crop/CropDetail.dart
+++ b/lib/ui/crop/CropDetail.dart
@@ -52,12 +52,12 @@ const CropDetailStyle _defaultStyle = const _DefaultStyle();
 
 class CropDetail extends StatelessWidget implements ListViewSection {
   final CropDetailStyle _style;
-  final ViewModelProvider<CropDetailViewModel> _viewModelProvider;
+  final ViewModelProviderInterface<CropDetailViewModel> _viewModelProvider;
   final Widget _header;
   SectionedListView _listBuilder;
   CropDetail._({
     Key key,
-    ViewModelProvider<CropDetailViewModel> provider,
+    ViewModelProviderInterface<CropDetailViewModel> provider,
     CropDetailStyle style,
     SectionedListView listBuilder,
     Widget header,
@@ -68,7 +68,7 @@ class CropDetail extends StatelessWidget implements ListViewSection {
         super(key: key);
 
   factory CropDetail(
-      {ViewModelProvider<CropDetailViewModel> provider,
+      {ViewModelProviderInterface<CropDetailViewModel> provider,
       CropDetailStyle style = _defaultStyle,
       Widget header}) {
     final listBuilder = SectionedListView(sections: []);
@@ -83,7 +83,7 @@ class CropDetail extends StatelessWidget implements ListViewSection {
   @override
   Widget build(BuildContext context) {
     final builder = ViewModelProviderBuilder(
-      provider: _viewModelProvider,
+      defaultProvider: _viewModelProvider,
       successBuilder: _buildSuccess,
     );
     return builder.build(context);

--- a/lib/ui/home.dart
+++ b/lib/ui/home.dart
@@ -75,7 +75,7 @@ class Home extends StatelessWidget {
     localizations = FarmsmartLocalizations.of(context);
 
     return ViewModelProviderBuilder(
-      provider: homeViewModelProvider,
+      defaultProvider: homeViewModelProvider,
       successBuilder: _buildSuccess,
     );
   }
@@ -162,12 +162,12 @@ class Home extends StatelessWidget {
   _buildDiscover() {
     return ArticleList(
       style: ArticleListStyles.buildForDiscover(),
-      viewModelProvider: ArticleListProvider(
+      /*viewModelProvider: ArticleListProvider(
         title: _LocalisedStrings.discover(),
         repository: repositoryProvider.getArticleRepository(),
         group: ArticleCollectionGroup.discovery,
         relatedTitle: _LocalisedStrings.relatedArticles(),
-      ),
+      ),*/
     );
   }
 

--- a/lib/ui/myplot/PlotDetail.dart
+++ b/lib/ui/myplot/PlotDetail.dart
@@ -68,13 +68,13 @@ class _DefaultStyle implements PlotDetailStyle {
 }
 
 class PlotDetail extends StatefulWidget {
-  final ViewModelProvider<PlotDetailViewModel> _viewModelProvider;
+  final ViewModelProviderInterface<PlotDetailViewModel> _viewModelProvider;
   final PlotDetailStyle _style;
   ArticleDetail _articleDetail;
 
   PlotDetail(
       {Key key,
-      ViewModelProvider<PlotDetailViewModel> provider,
+      ViewModelProviderInterface<PlotDetailViewModel> provider,
       PlotDetailStyle style = const _DefaultStyle()})
       : this._viewModelProvider = provider,
         this._style = style,
@@ -105,7 +105,7 @@ class _PlotDetailState extends State<PlotDetail> {
   @override
   Widget build(BuildContext context) {
     return ViewModelProviderBuilder(
-      provider: widget._viewModelProvider,
+      defaultProvider: widget._viewModelProvider,
       successBuilder: _successBuilder,
     );
   }
@@ -277,7 +277,7 @@ class _PlotDetailState extends State<PlotDetail> {
 
   void _tappedDetail({
     BuildContext context,
-    ViewModelProvider<CropDetailViewModel> provider,
+    ViewModelProviderInterface<CropDetailViewModel> provider,
   }) {
     Navigator.of(context).push(
       MaterialPageRoute(

--- a/lib/ui/myplot/PlotList.dart
+++ b/lib/ui/myplot/PlotList.dart
@@ -37,7 +37,7 @@ class PlotListViewModel implements LoadableViewModel, RefreshableViewModel {
   final LoadingStatus loadingStatus;
   final List<PlotListItemViewModel> items;
   final Function refresh;
-  final ViewModelProvider<RecommendationsListViewModel> recommendationsProvider;
+  final ViewModelProviderInterface<RecommendationsListViewModel> recommendationsProvider;
 
   PlotListViewModel({
     String title,
@@ -45,7 +45,7 @@ class PlotListViewModel implements LoadableViewModel, RefreshableViewModel {
     LoadingStatus loadingStatus,
     List<PlotListItemViewModel> items,
     Function refresh,
-    ViewModelProvider<RecommendationsListViewModel> recommendationsProvider,
+    ViewModelProviderInterface<RecommendationsListViewModel> recommendationsProvider,
   })  : this.title = title,
         this.loadingStatus = loadingStatus,
         this.buttonTitle = buttonTitle,
@@ -88,12 +88,12 @@ class _DefaultStyle implements PlotListStyle {
 }
 
 class PlotList extends StatelessWidget {
-  final ViewModelProvider<PlotListViewModel> _viewModelProvider;
+  final ViewModelProviderInterface<PlotListViewModel> _viewModelProvider;
   final PlotListStyle _style;
 
   const PlotList({
     Key key,
-    ViewModelProvider<PlotListViewModel> provider,
+    ViewModelProviderInterface<PlotListViewModel> provider,
     PlotListStyle style = const _DefaultStyle(),
   })  : this._viewModelProvider = provider,
         this._style = style,
@@ -102,7 +102,7 @@ class PlotList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ViewModelProviderBuilder(
-      provider: _viewModelProvider,
+      defaultProvider: _viewModelProvider,
       successBuilder: _buildPage,
     );
   }
@@ -230,7 +230,7 @@ class PlotList extends StatelessWidget {
 
   void _tappedAdd({
     BuildContext context,
-    ViewModelProvider<RecommendationsListViewModel> provider,
+    ViewModelProviderInterface<RecommendationsListViewModel> provider,
   }) {
     NavigationScope.presentModal(
       context,
@@ -240,7 +240,7 @@ class PlotList extends StatelessWidget {
 
   void _tappedListItem({
     BuildContext context,
-    ViewModelProvider<PlotDetailViewModel> provider,
+    ViewModelProviderInterface<PlotDetailViewModel> provider,
   }) {
     Navigator.of(context).push(
       MaterialPageRoute(

--- a/lib/ui/myplot/PlotListItem.dart
+++ b/lib/ui/myplot/PlotListItem.dart
@@ -13,7 +13,7 @@ class PlotListItemViewModel {
   final String detail;
   final double progress;
   final ImageURLProvider imageProvider;
-  final ViewModelProvider<PlotDetailViewModel> detailViewModelProvider;
+  final ViewModelProviderInterface<PlotDetailViewModel> detailViewModelProvider;
 
   PlotListItemViewModel(
       {String title,
@@ -21,7 +21,7 @@ class PlotListItemViewModel {
       String detail,
       double progress,
       ImageURLProvider imageProvider,
-      ViewModelProvider<PlotDetailViewModel> provider})
+      ViewModelProviderInterface<PlotDetailViewModel> provider})
       : this.title = title,
         this.subtitle = subtitle,
         this.detail = detail,

--- a/lib/ui/myplot/viewmodel/PlotDetailViewModel.dart
+++ b/lib/ui/myplot/viewmodel/PlotDetailViewModel.dart
@@ -15,7 +15,7 @@ class PlotDetailViewModel
     final int currentStage;
     final Function rename;
     final Function remove;
-    final ViewModelProvider<CropDetailViewModel> detailProvider;
+    final ViewModelProviderInterface<CropDetailViewModel> detailProvider;
 
   PlotDetailViewModel({String title, 
   String detailText, 
@@ -26,7 +26,7 @@ class PlotDetailViewModel
   int currentStage, 
   Function rename, 
   Function remove,
-  ViewModelProvider<CropDetailViewModel> detailProvider,}) : this.title = title, 
+  ViewModelProviderInterface<CropDetailViewModel> detailProvider,}) : this.title = title, 
   this.detailText = detailText, 
   this.progress = progress, 
   this.imageProvider = imageProvider,

--- a/lib/ui/profile/Profile.dart
+++ b/lib/ui/profile/Profile.dart
@@ -125,7 +125,7 @@ class ProfileViewModel implements RefreshableViewModel, LoadableViewModel {
   final String initials;
   final int activeCrops;
   final int completedCrops;
-  final ViewModelProvider<SwitchProfileListViewModel> switchProfileProvider;
+  final ViewModelProviderInterface<SwitchProfileListViewModel> switchProfileProvider;
   final ImageURLProvider image;
   final Function refresh;
   final Function logout;
@@ -249,12 +249,12 @@ class _DefaultStyle extends ProfileStyle {
 const ProfileStyle _defaultStyle = const _DefaultStyle();
 
 class Profile extends StatelessWidget {
-  final ViewModelProvider<ProfileViewModel> _viewModelProvider;
+  final ViewModelProviderInterface<ProfileViewModel> _viewModelProvider;
   final ProfileStyle _style;
 
   const Profile({
     Key key,
-    ViewModelProvider<ProfileViewModel> provider,
+    ViewModelProviderInterface<ProfileViewModel> provider,
     ProfileStyle style = _defaultStyle,
   })  : this._viewModelProvider = provider,
         this._style = style,
@@ -263,7 +263,7 @@ class Profile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ViewModelProviderBuilder(
-      provider: _viewModelProvider,
+      defaultProvider: _viewModelProvider,
       successBuilder: _buildPage,
     );
   }
@@ -441,7 +441,7 @@ class Profile extends StatelessWidget {
 
   void _tappedSwitchProfile({
     BuildContext context,
-    ViewModelProvider<SwitchProfileListViewModel> provider,
+    ViewModelProviderInterface<SwitchProfileListViewModel> provider,
   }) {
     Navigator.of(context).push(
       MaterialPageRoute(

--- a/lib/ui/profile/SwitchProfileList.dart
+++ b/lib/ui/profile/SwitchProfileList.dart
@@ -82,12 +82,12 @@ class _DefaultStyle extends SwitchProfileListStyle {
 const SwitchProfileListStyle _defaultStyle = const _DefaultStyle();
 
 class SwitchProfileList extends StatefulWidget {
-  final ViewModelProvider<SwitchProfileListViewModel> _provider;
+  final ViewModelProviderInterface<SwitchProfileListViewModel> _provider;
   final SwitchProfileListStyle _style;
 
   SwitchProfileList({
     Key key,
-    ViewModelProvider<SwitchProfileListViewModel> provider,
+    ViewModelProviderInterface<SwitchProfileListViewModel> provider,
     SwitchProfileListStyle style = _defaultStyle,
   })  : this._provider = provider,
         this._style = style,
@@ -100,7 +100,7 @@ class SwitchProfileList extends StatefulWidget {
 class SwitchProfileListState extends State<SwitchProfileList> {
   @override
   Widget build(BuildContext context) {
-    return ViewModelProviderBuilder(provider: widget._provider, successBuilder: _buildSuccess,);
+    return ViewModelProviderBuilder(defaultProvider: widget._provider, successBuilder: _buildSuccess,);
   }
   Widget _buildSuccess({BuildContext context, AsyncSnapshot<SwitchProfileListViewModel> snapshot}) {
     final viewModel = snapshot.data;

--- a/lib/ui/profile/SwitchProfileListItem.dart
+++ b/lib/ui/profile/SwitchProfileListItem.dart
@@ -24,7 +24,7 @@ class SwitchProfileListItemViewModel {
   Function tapAction;
   Function switchAction;
   bool isSelected;
-  final ViewModelProvider<ProfileViewModel> avatarViewModelProvider;
+  final ViewModelProviderInterface<ProfileViewModel> avatarViewModelProvider;
 
   SwitchProfileListItemViewModel({
     this.title,

--- a/lib/ui/profitloss/ProfitLossList.dart
+++ b/lib/ui/profitloss/ProfitLossList.dart
@@ -83,12 +83,12 @@ class _DefaultStyle implements ProfitLossStyle {
 }
 
 class ProfitLossPage extends StatelessWidget {
-  final ViewModelProvider<ProfitLossListViewModel> _viewModelProvider;
+  final ViewModelProviderInterface<ProfitLossListViewModel> _viewModelProvider;
   final ProfitLossStyle _style;
 
   const ProfitLossPage(
       {Key key,
-      ViewModelProvider<ProfitLossListViewModel> viewModelProvider,
+      ViewModelProviderInterface<ProfitLossListViewModel> viewModelProvider,
       ProfitLossStyle style = const _DefaultStyle()})
       : this._viewModelProvider = viewModelProvider,
         this._style = style,
@@ -97,7 +97,7 @@ class ProfitLossPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ViewModelProviderBuilder(
-      provider: _viewModelProvider,
+      defaultProvider: _viewModelProvider,
       successBuilder: _buildPageWithFloatingButton,
     );
   }

--- a/lib/ui/recommendations/RecommentationsList.dart
+++ b/lib/ui/recommendations/RecommentationsList.dart
@@ -107,11 +107,11 @@ const RecommendedListStyle _defaultStyle = const _DefaultStyle();
 
 class RecommendationsList extends StatelessWidget implements ListViewSection {
   final RecommendedListStyle _style;
-  final ViewModelProvider<RecommendationsListViewModel> _viewModelProvider;
+  final ViewModelProviderInterface<RecommendationsListViewModel> _viewModelProvider;
 
   const RecommendationsList({
     Key key,
-    ViewModelProvider<RecommendationsListViewModel> provider,
+    ViewModelProviderInterface<RecommendationsListViewModel> provider,
     RecommendedListStyle style = _defaultStyle,
   })  : this._style = style,
         this._viewModelProvider = provider,
@@ -120,7 +120,7 @@ class RecommendationsList extends StatelessWidget implements ListViewSection {
   @override
   Widget build(BuildContext context) {
     return ViewModelProviderBuilder(
-      provider: _viewModelProvider,
+      defaultProvider: _viewModelProvider,
       successBuilder: _buildSuccess,
     );
   }
@@ -260,7 +260,7 @@ class RecommendationsList extends StatelessWidget implements ListViewSection {
 
   void _tappedDetail({
     BuildContext context,
-    ViewModelProvider<CropDetailViewModel> provider,
+    ViewModelProviderInterface<CropDetailViewModel> provider,
     RecommendationCardViewModel recommendationCardViewModel,
   }) {
     Navigator.of(context).push(

--- a/lib/ui/recommendations/recommendation_card/recommendation_card_view_model.dart
+++ b/lib/ui/recommendations/recommendation_card/recommendation_card_view_model.dart
@@ -10,7 +10,7 @@ class RecommendationCardViewModel {
   String detailActionText;
   String addActionText;
   double score;
-  ViewModelProvider<CropDetailViewModel> detailProvider;
+  ViewModelProviderInterface<CropDetailViewModel> detailProvider;
   Function detailAction;
   Function addAction;
   bool isAdded;

--- a/lib/ui/recommendations/viewmodel/RecommendationsListViewModel.dart
+++ b/lib/ui/recommendations/viewmodel/RecommendationsListViewModel.dart
@@ -6,7 +6,7 @@ import 'package:farmsmart_flutter/ui/crop/viewmodel/CropDetailViewModel.dart';
 import 'package:farmsmart_flutter/ui/recommendations/recommendation_card/recommendation_card_view_model.dart';
 
 typedef BoolFunction = bool Function();
-typedef DetailProviderFunction = ViewModelProvider<CropDetailViewModel> Function();
+typedef DetailProviderFunction = ViewModelProviderInterface<CropDetailViewModel> Function();
 
 class RecommendationsListViewModel implements RefreshableViewModel, LoadableViewModel{
   static final error = RecommendationsListViewModel(loadingStatus: LoadingStatus.ERROR);

--- a/lib/ui/startup/startup.dart
+++ b/lib/ui/startup/startup.dart
@@ -1,17 +1,22 @@
+import 'package:farmsmart_flutter/flavors/app_config.dart';
 import 'package:farmsmart_flutter/model/bloc/ViewModelProvider.dart';
+import 'package:farmsmart_flutter/model/bloc/article/ArticleListProvider.dart';
+import 'package:farmsmart_flutter/model/repositories/article/ArticleRepositoryInterface.dart';
 import 'package:farmsmart_flutter/ui/LandingPage.dart';
+import 'package:farmsmart_flutter/ui/article/viewModel/ArticleListViewModel.dart';
 import 'package:farmsmart_flutter/ui/common/ViewModelProviderBuilder.dart';
 import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
 
 import 'viewmodel/startupViewModel.dart';
 
 class Startup extends StatelessWidget {
-  final ViewModelProvider<StartupViewModel> _provider;
+  final ViewModelProviderInterface<StartupViewModel> _provider;
   final Widget _home;
 
   const Startup({
     Key key,
-    ViewModelProvider<StartupViewModel> provider,
+    ViewModelProviderInterface<StartupViewModel> provider,
     Widget home,
     Widget loginSignup,
   })  : this._provider = provider,
@@ -21,7 +26,7 @@ class Startup extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ViewModelProviderBuilder(
-      provider: _provider,
+      defaultProvider: _provider,
       successBuilder: _successBuilder,
     );
   }
@@ -38,6 +43,16 @@ class Startup extends StatelessWidget {
   }
 
   Widget _homeBuilder({BuildContext context, StartupViewModel viewModel}) {
-    return _home;
+   final repositoryProvider = AppConfig.of(context).repositoryProvider;
+
+   final articleProvider = ArticleListProvider(
+        title: "title",
+        repository: repositoryProvider.getArticleRepository(),
+        group: ArticleCollectionGroup.discovery,
+        relatedTitle: "related",
+      );
+
+    return Provider<ViewModelProviderInterface<ArticleListViewModel>>.value(
+  value: articleProvider, child:_home);
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -415,6 +415,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.0"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.0"
   pub_semver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
     sdk: flutter
   image_picker: ^0.6.0+20
   image_cropper: ^1.0.2
+  provider: ^3.1.0
 
   flutter_localizations:
     sdk: flutter


### PR DESCRIPTION
Rename the ViewModelProvider abstract class to ViewModelProviderInterface to avoid confusion
Added the Provider lib dependency.
Injected the Article View Model provider using the new provider system.
Removed the old Article View Model provider constructor injection.
Now an Article View Model Provider (something that provides article view Models) can be accessed from any part of the widget tree!

Why?

This allows us to inject view model providers into the widget tree and access them at any point in the lower tree. This will remove the need to pass on any view model providers to detail screens or any sub screen.